### PR TITLE
Fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from rejected import __version__
 import sys
 
 classifiers = ['Development Status :: 5 - Production/Stable',
@@ -24,7 +23,7 @@ if sys.version_info < (2, 7, 0):
     install_requires.append('importlib')
 
 setup(name='rejected',
-      version=__version__,
+      version='3.5.0',
       description='Rejected is a Python RabbitMQ Consumer Framework and '
                   'Controller Daemon',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR fixes source-based distributions by adding the LICENSE and README that _setup.py_ requires to a manifest and hard-codes the version number in _setup.py_ to avoid the imports in _rejected/consumer.py_.