### PR TITLE
Add consumer log_exception

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rejected'
-copyright = u'2014, Gavin M. Roy'
+copyright = u'2014-15, Gavin M. Roy'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/rejected/__init__.py
+++ b/rejected/__init__.py
@@ -4,7 +4,7 @@ Rejected is a Python RabbitMQ Consumer Framework and Controller Daemon
 """
 __author__ = 'Gavin M. Roy <gavinmroy@gmail.com>'
 __since__ = "2009-09-10"
-__version__ = "3.6.1"
+__version__ = "3.6.2"
 
 from consumer import Consumer
 from consumer import PublishingConsumer

--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -201,7 +201,7 @@ class Consumer(object):
         the ``config`` section for the consumer in the rejected configuration.
 
         .. deprecated:: 3.1
-            Use :property:`settings` instead.
+            Use :attr:`.settings` instead.
 
         :rtype: dict
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info < (2, 7, 0):
     install_requires.append('importlib')
 
 setup(name='rejected',
-      version='3.6.1',
+      version='3.6.2',
       description='Rejected is a Python RabbitMQ Consumer Framework and '
                   'Controller Daemon',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR replaces `Process.record_exception` with `Consumer.log_exception`.  The new method logs the exception information at `logging.ERROR` and the condensed stack traceback at `logging.DEBUG`.  It also forwards the exception information over to `Process.send_exception_to_sentry`.  This will continue to report unhandled exceptions to Sentry and allow rejected consumers to report handled exceptions as well by explicitly calling `self.log_exception(...)`.