### PR TITLE
More sentry info

### DIFF
--- a/rejected/process.py
+++ b/rejected/process.py
@@ -663,6 +663,7 @@ class Process(multiprocessing.Process, state.State):
         if not self.sentry_client:
             return
 
+        message = dict(self.message)
         duration = math.ceil(time.time() - self.delivery_time) * 1000
         kwargs = {'logger': 'rejected.processs',
                   'modules': self.get_module_data(),
@@ -670,7 +671,9 @@ class Process(multiprocessing.Process, state.State):
                       'consumer': self.consumer_name,
                       'connection': self.connection_name,
                       'env': self.strip_uri_passwords(dict(os.environ)),
-                      'message': dict(self.message)},
+                      'message': message},
+                  'tags': {
+                      'message_type': message.get('type', 'none')},
                   'time_spent': duration}
         LOGGER.debug('Sending exception to sentry: %r', kwargs)
         self.sentry_client.captureException(exc_info, **kwargs)

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -706,7 +706,11 @@ class Process(multiprocessing.Process, state.State):
 
         # Setup the Sentry client
         if raven and 'sentry_dsn' in cfg:
-            options = {'tags': {'consumer_type': consumer_name}}
+            options = {
+                'tags': {'consumer_type': consumer_name},
+                'include_paths': ['pika', 'rejected', 'tornado',
+                                  self.config['consumer']],
+            }
             self.sentry_client = raven.Client(cfg['sentry_dsn'], **options)
 
         # Setup the stats counter instance

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -703,7 +703,8 @@ class Process(multiprocessing.Process, state.State):
 
         # Setup the Sentry client
         if raven and 'sentry_dsn' in cfg:
-            self.sentry_client = raven.Client(cfg['sentry_dsn'])
+            options = {'tags': {'consumer_type': consumer_name}}
+            self.sentry_client = raven.Client(cfg['sentry_dsn'], **options)
 
         # Setup the stats counter instance
         self.stats = stats.Stats(self.name, consumer_name, cfg['statsd'] or {})


### PR DESCRIPTION
This PR adds a little more information in the Sentry exceptions.  In particular exception traces are tagged with the AMQP message type (if set) and the consumer name.  I also took the liberty of setting the `include_path` which causes the raven code to [retrieve version numbers](https://github.com/getsentry/raven-python/blob/master/raven/base.py#L215-L224) using the [goodness within `pkg_resources`](https://github.com/getsentry/raven-python/blob/master/raven/utils/__init__.py#L87-L120).