### PR TITLE
Improve sentry support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,10 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-intersphinx_mapping = {'python': ('https://docs.python.org/2.7/', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/2.7/', None),
+    'raven': ('https://raven.readthedocs.org/en/latest/', None)
+}
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Rejected runs as a master process with multiple consumer configurations that are
 each run it an isolated process. It has the ability to collect statistical
 data from the consumer processes and report on it.
 
-|Version| |Downloads| |License|
+|Version| |Downloads| |Status| |Climate| |License|
 
 Features
 --------
@@ -57,8 +57,6 @@ Source
 ------
 rejected source is available on Github at  `https://github.com/gmr/rejected <https://github.com/gmr/rejected>`_
 
-|Status|
-
 Version History
 ---------------
 See :doc:`history`
@@ -71,14 +69,17 @@ Indices and tables
 * :ref:`search`
 
 
-.. |Version| image:: https://badge.fury.io/py/rejected.svg?
-   :target: http://badge.fury.io/py/rejected
-
-.. |Status| image:: https://travis-ci.org/gmr/rejected.svg?branch=master
-   :target: https://travis-ci.org/gmr/rejected
-
-.. |Downloads| image:: https://pypip.in/d/rejected/badge.svg?
+.. |Version| image:: https://img.shields.io/pypi/v/rejected.svg?
    :target: https://pypi.python.org/pypi/rejected
 
-.. |License| image:: https://pypip.in/license/rejected/badge.svg?
+.. |Status| image:: https://img.shields.io/travis/gmr/rejected.svg?
+   :target: https://travis-ci.org/gmr/rejected
+
+.. |Downloads| image:: https://img.shields.io/pypi/dm/rejected.svg?
+   :target: https://pypi.python.org/pypi/rejected
+
+.. |License| image:: https://img.shields.io/pypi/l/rejected.svg?
    :target: https://rejected.readthedocs.org
+
+.. |Climate| image:: https://img.shields.io/codeclimate/github/gmr/rejected.svg?
+   :target: https://codeclimate.com/github/gmr/rejected

--- a/rejected/__init__.py
+++ b/rejected/__init__.py
@@ -4,7 +4,7 @@ Rejected is a Python RabbitMQ Consumer Framework and Controller Daemon
 """
 __author__ = 'Gavin M. Roy <gavinmroy@gmail.com>'
 __since__ = "2009-09-10"
-__version__ = "3.6.2"
+__version__ = "3.6.3"
 
 from consumer import Consumer
 from consumer import PublishingConsumer

--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -376,6 +376,21 @@ class Consumer(object):
         """
         return self._message.properties.user_id
 
+    @property
+    def sentry_client(self):
+        """
+        Access the raven ``Client`` instance or ``None``
+
+        :rtype: :class:`raven.base.Client`
+
+        Use this object to add tags or additional context to Sentry
+        error reports (see :meth:`raven.base.Client.tags_context`) or
+        to report messages (via :meth:`raven.base.Client.captureMessage`)
+        directly to Sentry.
+
+        """
+        return self._process.sentry_client
+
     def _clear(self):
         """Resets all assigned data for the current message."""
         self._finished = False

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -673,7 +673,7 @@ class Process(multiprocessing.Process, state.State):
                       'env': self.strip_uri_passwords(dict(os.environ)),
                       'message': message},
                   'tags': {
-                      'message_type': message.get('type', 'none')},
+                      'message_type': message['properties'].type or 'none'},
                   'time_spent': duration}
         LOGGER.debug('Sending exception to sentry: %r', kwargs)
         self.sentry_client.captureException(exc_info, **kwargs)

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -692,6 +692,16 @@ class Process(multiprocessing.Process, state.State):
         """
         LOGGER.info('Initializing for %s on %s connection', self.name,
                     connection_name)
+
+        # Setup the Sentry client
+        if raven and 'sentry_dsn' in cfg:
+            options = {
+                'tags': {'consumer_type': consumer_name},
+                'include_paths': ['pika', 'rejected', 'tornado',
+                                  cfg['Consumers'][consumer_name]['consumer']],
+            }
+            self.sentry_client = raven.Client(cfg['sentry_dsn'], **options)
+
         self.connection_name = connection_name
         self.consumer_name = consumer_name
         self.config = cfg['Consumers'][consumer_name]
@@ -703,15 +713,6 @@ class Process(multiprocessing.Process, state.State):
             LOGGER.critical('Could not import and start processor')
             self.set_state(self.STATE_STOPPED)
             exit(1)
-
-        # Setup the Sentry client
-        if raven and 'sentry_dsn' in cfg:
-            options = {
-                'tags': {'consumer_type': consumer_name},
-                'include_paths': ['pika', 'rejected', 'tornado',
-                                  self.config['consumer']],
-            }
-            self.sentry_client = raven.Client(cfg['sentry_dsn'], **options)
 
         # Setup the stats counter instance
         self.stats = stats.Stats(self.name, consumer_name, cfg['statsd'] or {})

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info < (2, 7, 0):
     install_requires.append('importlib')
 
 setup(name='rejected',
-      version='3.6.2',
+      version='3.6.3',
       description='Rejected is a Python RabbitMQ Consumer Framework and '
                   'Controller Daemon',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR makes the Raven client instance directly available to the consumer through a new property conspicuously named ``sentry_client``.  Consumer creation was modified a little to ensure that the sentry client exists before we create the consumer so that it is available for customization in ``Consumer.initialize``.