### PR TITLE
Remove routing key from metric path

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2015, Gavin M. Roy
+Copyright (c) 2009-2016, Gavin M. Roy
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rejected'
-copyright = u'2014-15, Gavin M. Roy'
+copyright = u'2014-16, Gavin M. Roy'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/rejected/__init__.py
+++ b/rejected/__init__.py
@@ -4,7 +4,7 @@ Rejected is a Python RabbitMQ Consumer Framework and Controller Daemon
 """
 __author__ = 'Gavin M. Roy <gavinmroy@gmail.com>'
 __since__ = '2009-09-10'
-__version__ = '3.12.2'
+__version__ = '3.13'
 
 import sys
 import logging

--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -764,8 +764,7 @@ class PublishingConsumer(Consumer):
 
         # Publish the message
         self.logger.debug('Publishing message to %s:%s', exchange, routing_key)
-        with self.statsd_track_duration('publish.{}.{}'.format(exchange,
-                                                               routing_key)):
+        with self.statsd_track_duration('publish.{}'.format(exchange)):
             self._channel.basic_publish(exchange=exchange,
                                         routing_key=routing_key,
                                         properties=msg_props,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.version_info < (2, 7, 0):
     install_requires.append('importlib')
 
 setup(name='rejected',
-      version='3.12.2',
+      version='3.13',
       description='Rejected is a Python RabbitMQ Consumer Framework and '
                   'Controller Daemon',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
Having the routing key in the metric path causes enormous growth in the number of reported metric paths when the routing key is used for fine-grained routing.