### PR TITLE
testing: remove extraneous call to initialize()

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Next Release
+------------
+
+- Remove extra call to :py:meth:`rejected.consumer.Consumer.initialize` in
+  :py:meth:`rejected.testing.AsyncTestCase._create_consumer`
+
 3.19.5
 ------
 

--- a/rejected/testing.py
+++ b/rejected/testing.py
@@ -258,7 +258,6 @@ class AsyncTestCase(testing.AsyncTestCase):
         """
         cls = self.get_consumer()
         obj = cls(config.Data(self.get_settings()), self.process)
-        obj.initialize()
         obj._message = self.create_message('dummy')
         obj.set_channel('mock', self.process.connections['mock'].channel)
         return obj


### PR DESCRIPTION
Creating the consumer class already calls `initialize` and there are some consumers (_none of mine of course_) that don't implement this in a idempotent manner.