### PR TITLE
Properly shutdown consumer in AsyncTestCase.tearDown

### DIFF
--- a/rejected/testing.py
+++ b/rejected/testing.py
@@ -118,6 +118,7 @@ class AsyncTestCase(testing.AsyncTestCase):
         super(AsyncTestCase, self).tearDown()
         if not self.consumer.is_finished:
             self.consumer.finish()
+        self.consumer.shutdown()
 
     def get_consumer(self):
         """Override to return the consumer class for testing.


### PR DESCRIPTION
Since a new consumer is created in `AsyncTestCase.setUp`, it should also be fully cleaned up in `AsyncTestCase.tearDown`. 

Ran into this issue while testing a consumer that closed database connections in its `shutdown` method. Since it wasn't being executed, the tests ended up exceeding the maximum number of connections to the limited local database.