### PR TITLE
Testing create consumer running initialize twice

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.20.4
+------
+
+- FIXED :meth:`~rejected.consumer.Consumer.initialize` getting called twice in `rejected.testing`
+
 3.20.3
 ------
 

--- a/rejected/testing.py
+++ b/rejected/testing.py
@@ -261,7 +261,6 @@ class AsyncTestCase(testing.AsyncTestCase):
         """
         cls = self.get_consumer()
         obj = cls(config.Data(self.get_settings()), self.process)
-        obj.initialize()
         obj._message = self.create_message('dummy')
         obj.set_channel('mock', self.process.connections['mock'].channel)
         return obj

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='rejected',
-    version='3.20.3',
+    version='3.20.4',
     description='Rejected is a Python RabbitMQ Consumer Framework and '
                 'Controller Daemon',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
rejected.consumer.Consumer.initialize is already called from __init__ so explicit call is unnecessary.