### PR TITLE
Fix Python 3.9 support

### DIFF
--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -1531,7 +1531,7 @@ class SmartConsumer(Consumer):
         if isinstance(value, bytes):
             value = value.decode('utf-8')
         try:
-            return json.loads(value, encoding='utf-8')
+            return json.loads(value)
         except ValueError as error:
             self.logger.exception('Could not decode message body: %s', error)
             raise MessageException(error)


### PR DESCRIPTION
Python 3.9 removed the encoding kwarg from `json.loads`. Attempting to use it results in an error. 

It has been defaulting to utf-8 since at least 2.7 so removing it from rejected should be a non-issue.