### PR TITLE
Include requires/installation.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include LICENSE
 include README.rst
+include requires/testing.txt
+include requires/installation.txt


### PR DESCRIPTION
This fixes the conda package build that is currently failing based on the sdist: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=231773&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642&l=463