### PR TITLE
Fix republished messages in AsyncTestCase.published_messages

### DIFF
--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -1110,10 +1110,10 @@ class Consumer(object):
         properties['headers']['X-Original-Exchange'] = self._message.exchange
 
         self._message.channel.basic_publish(
-            self._drop_exchange,
-            self._message.routing_key,
-            self._message.body,
-            pika.BasicProperties(**properties))
+            exchange=self._drop_exchange,
+            routing_key=self._message.routing_key,
+            body=self._message.body,
+            properties=pika.BasicProperties(**properties))
 
     def _republish_processing_error(self, error):
         """Republish the original message that was received because a
@@ -1144,10 +1144,10 @@ class Consumer(object):
                 properties['headers'][_PROCESSING_EXCEPTIONS] = 1
 
         self._message.channel.basic_publish(
-            self._error_exchange,
-            self._message.routing_key,
-            self._message.body,
-            pika.BasicProperties(**properties))
+            exchange=self._error_exchange,
+            routing_key=self._message.routing_key,
+            body=self._message.body,
+            properties=pika.BasicProperties(**properties))
 
 
 class PublishingConsumer(Consumer):

--- a/rejected/testing.py
+++ b/rejected/testing.py
@@ -104,8 +104,14 @@ class AsyncTestCase(testing.AsyncTestCase):
         :returns: list([:class:`~rejected.testing.PublishedMessage`])
 
         """
-        return [PublishedMessage(*c[1], **c[2])
-                for c in self.channel.basic_publish.mock_calls]
+        return [
+            PublishedMessage(
+                body=c[2]['body'],
+                exchange=c[2]['exchange'],
+                properties=c[2]['properties'],
+                routing_key=c[2]['routing_key'])
+            for c in self.channel.basic_publish.mock_calls
+        ]
 
     def get_consumer(self):
         """Override to return the consumer class for testing.

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+"""Tests for rejected.testing"""
+from rejected import consumer, testing
+
+
+class TestPublishedMessages(testing.AsyncTestCase):
+
+    def get_consumer(self):
+        class Consumer(consumer.SmartConsumer):
+            def process(self):
+                for i in range(10):
+                    self.publish_message(
+                        exchange='my_exchange',
+                        routing_key='my_routing_key',
+                        body=i,
+                        properties={
+                            'type': 'my_type',
+                            'content_type': 'my_content_type'
+                        })
+        return Consumer
+
+    def test_order_preserved(self):
+        self.process_message()
+        self.assertEqual(10, len(self.published_messages))
+        for i, published_message in zip(range(10), self.published_messages):
+            self.assertEqual(i, published_message.body)
+            self.assertEqual('my_exchange', published_message.exchange)
+            self.assertEqual('my_routing_key', published_message.routing_key)
+            self.assertEqual('my_type',
+                             published_message.properties.type)
+            self.assertEqual('my_content_type',
+                             published_message.properties.content_type)
+
+
+class TestProcessingException(testing.AsyncTestCase):
+
+    def get_consumer(self):
+        class Consumer(consumer.SmartConsumer):
+            def process(self):
+                raise consumer.ProcessingException
+        return Consumer
+
+    def test_republished(self):
+        self.process_message()
+        self.assertEqual(1, len(self.published_messages))
+        published_message = self.published_messages[0]
+
+        self.assertEqual(
+            self.consumer._message.routing_key,
+            published_message.routing_key)
+        self.assertEqual(
+            self.consumer._error_exchange,
+            published_message.exchange)
+        self.assertEqual(
+            self.consumer._message.body,
+            published_message.body)
+        for (attr, value) in self.consumer._message.properties:
+            if attr == 'headers':
+                self.assertEqual(
+                    {'X-Processing-Exception': 'ProcessingException',
+                     'X-Processing-Exceptions': 1},
+                    published_message.properties.headers)
+            else:
+                self.assertEqual(
+                    value, getattr(published_message.properties, attr))
+
+
+class TestMessageException(testing.AsyncTestCase):
+
+    def get_consumer(self):
+        class Consumer(consumer.SmartConsumer):
+            MESSAGE_TYPE = 'a_type'
+        return Consumer
+
+    def test_no_drop(self):
+        self.process_message()
+        self.assertEqual(0, len(self.published_messages))
+
+    def test_drop(self):
+        self.consumer._drop_exchange = 'drop'
+        self.consumer._drop_invalid = True
+        self.process_message(message_type='bad_type')
+        self.assertEqual(1, len(self.published_messages))
+        published_message = self.published_messages[0]
+
+        self.assertEqual(
+            self.consumer._message.routing_key,
+            published_message.routing_key)
+        self.assertEqual(
+            self.consumer._drop_exchange,
+            published_message.exchange)
+        self.assertEqual(
+            self.consumer._message.body,
+            published_message.body)
+        for (attr, value) in self.consumer._message.properties:
+            if attr == 'headers':
+                headers = published_message.properties.headers
+                self.assertTrue(headers.pop('X-Dropped-Timestamp'))
+                self.assertEqual(
+                    {'X-Dropped-By': 'Consumer',
+                     'X-Dropped-Reason': 'invalid type',
+                     'X-Original-Exchange': 'rejected'},
+                    headers)
+            else:
+                self.assertEqual(
+                    value, getattr(published_message.properties, attr))


### PR DESCRIPTION
Fix republished messages in AsyncTestCase.published_messages
- fix PublishedMessage body and properties being swapped for republished messages.
  This was due to the *arg order being different in basic_publish calls
  and what PublishedMessage was expecting.
- add rudimentary tests for rejected.testing

---
Tested on:
- Python 2.7
- Python 3.7
- Python 3.9