### PR TITLE
3.20: Include requires/development.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.rst
 include requires/testing.txt
 include requires/installation.txt
+include requires/development.txt


### PR DESCRIPTION
Follow-up to https://github.com/gmr/rejected/pull/39, `development.txt` also needs to be included in the `sdist` otherwise the `setup.py` cannot be executed as seen in https://github.com/conda-forge/rejected-feedstock/pull/34