### PR TITLE
Bump pika version from 0.13.1 to 1.2.0

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -94,10 +94,32 @@ Each RabbitMQ connection entry should be a nested object with a unique name with
 |                 +---------------------+---------------------------------------------------------------+
 |                 | pass                | The password to use (str)                                     |
 |                 +---------------------+---------------------------------------------------------------+
-|                 | ssl                 | Optional: whether to connect via SSL (boolean) default: False |
+|                 | `ssl_options`_      | Optional: the SSL options for the `SSL connection socket`_    |
 |                 +---------------------+---------------------------------------------------------------+
 |                 | heartbeat_interval  | Optional: the AMQP heartbeat interval (int) default: 300 sec  |
 +-----------------+---------------------+---------------------------------------------------------------+
+
+ssl_options
+^^^^^^^^^^^
++---------------------------+---------------------------------------------------------------------------------------------------------+
+| Connections > ssl_options |                                                                                                         |
++===========================+==============+==========================================================================================+
+|                           | ca_certs     | The file path to the concatenated list of CA certificates (str)                          |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | ca_path      | The directory path to the PEM formatted CA certificates (str)                            |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | ca_data      | The PEM encoded CA certificates (str)                                                    |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | prototcol    | The ssl `PROTOCOL_*`_ enum integer value. Default: ``2`` for enum ``PROTOCOL_TLS`` (int) |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | certfile     | The file path to the PEM formatted certificate file (str)                                |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | keyfile      | The file path to the certificate private key (str)                                       |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | password     | The password for decrypting the ``keyfile`` private key (str)                            |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
+|                           | ciphers      | The set of available ciphers in the OpenSSL cipher list format (str)                     |
++---------------------------+--------------+------------------------------------------------------------------------------------------+
 
 Consumers
 ^^^^^^^^^
@@ -253,3 +275,6 @@ If the value is set to true and the application is not running in the foreground
 Troubleshooting
 ^^^^^^^^^^^^^^^
 If you find that your application is not logging anything or sending output to the terminal, ensure that you have created a logger section in your configuration for your consumer package. For example if your Consumer instance is named ``myconsumer.MyConsumer`` make sure there is a ``myconsumer`` logger in the logging configuration.
+
+.. _SSL connection socket: https://docs.python.org/3/library/ssl.html#ssl.wrap_socket
+.. _PROTOCOL_*: https://docs.python.org/3/library/ssl.html#ssl.SSLContext

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,7 @@ Changelog
   - Set the callback as a kwarg for channel.confirm_delivery since new parameter was introduced.
   - Renamed `self.handle` to `self.connection` in Connection class for reference to pika.tornado_connection.TornadoConnection.
   - Add handling for new :exc:`pika.exceptions.ConnectionWrongStateError` when closing channel or connection.
+  - Add support for `ssl_options` config parameters and deprecate `ssl` since it is no longer supported.
 
 3.21.1
 ------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+3.22.0
+------
+- Bump pika version from 0.13.1 to 1.2.0
+  - Update kwargs to basic_qos call since parameter names and order changed.
+  - Update kwargs to basic_consume call since parameter names and order changed.
+  - Update on_channel_closed callback to expect the closing_reason since the reply_code and reply_text were moved to attributes of the ChannelClosed exception.
+  - Set the callback as a kwarg for channel.confirm_delivery since new parameter was introduced.
+  - Renamed `self.handle` to `self.connection` in Connection class for reference to pika.tornado_connection.TornadoConnection.
+  - Add handling for new :exc:`pika.exceptions.ConnectionWrongStateError` when closing channel or connection.
+
 3.21.1
 ------
 - FIXED an issue with a uncaught exception raised when connecting or reconnecting and can't a socket can not be connected.

--- a/rejected/__init__.py
+++ b/rejected/__init__.py
@@ -18,7 +18,7 @@ from rejected.consumer import (  # noqa: E402
 
 __author__ = 'Gavin M. Roy <gavinmroy@gmail.com>'
 __since__ = '2009-09-10'
-__version__ = '3.21.1'
+__version__ = '3.22.0'
 
 __all__ = [
     '__author__',

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -69,7 +69,7 @@ class Connection(state.State):
         self.io_loop = io_loop
         self.name = name
         self.publisher_confirm = publisher_confirmations
-        self.handle = self.connect()
+        self.connection = self.connect()
 
         # Override STOPPED with CLOSED
         self.STATES[0x08] = 'CLOSED'
@@ -79,15 +79,19 @@ class Connection(state.State):
         return self.is_stopped
 
     def connect(self):
+        """Setup the TornadoConnection which connects to RabbitMQ
+        automatically with connection callbacks for when the connection is
+        opened, when there is an error opening a connection or when a
+        previously opened connection is closed.
+
+        """
         self.set_state(self.STATE_CONNECTING)
-        connection = tornado_connection.TornadoConnection(
+        return tornado_connection.TornadoConnection(
             self._connection_parameters,
-            stop_ioloop_on_close=False,
+            on_open_callback=self.on_open,
+            on_open_error_callback=self.on_open_error,
+            on_close_callback=self.on_closed,
             custom_ioloop=self.io_loop)
-        connection.add_on_close_callback(self.on_closed)
-        connection.add_on_open_callback(self.on_open)
-        connection.add_on_open_error_callback(self.on_open_error)
-        return connection
 
     def shutdown(self):
         if self.is_shutting_down:
@@ -104,23 +108,23 @@ class Connection(state.State):
         else:
             self.channel.close()
 
-    def on_open(self, handle):
+    def on_open(self, connection):
         """Invoked when the connection is opened
 
-        :type handle: pika.adapters.tornado_connection.TornadoConnection
+        :type connection: pika.adapters.tornado_connection.TornadoConnection
 
         """
-        LOGGER.debug('Connection %s is open (%r)', self.name, handle)
-        self.handle = handle
+        LOGGER.debug('Connection %s is open (%r)', self.name, connection)
+        self.connection = connection
         try:
-            self.handle.channel(self.on_channel_open)
+            self.connection.channel(on_open_callback=self.on_channel_open)
         except exceptions.ConnectionClosed:
             LOGGER.warning('Channel open on closed connection')
             self.set_state(self.STATE_CLOSED)
             self.callbacks.on_closed(self.name)
             return
-        self.handle.add_on_connection_blocked_callback(self.on_blocked)
-        self.handle.add_on_connection_unblocked_callback(self.on_unblocked)
+        self.connection.add_on_connection_blocked_callback(self.on_blocked)
+        self.connection.add_on_connection_unblocked_callback(self.on_unblocked)
 
     def on_open_error(self, *args, **kwargs):
         LOGGER.error('Connection %s failure %r %r', self.name, args, kwargs)
@@ -162,10 +166,10 @@ class Connection(state.State):
         self.channel.add_on_cancel_callback(self.on_consumer_cancelled)
         self.channel.add_on_return_callback(self.on_return)
         if self.publisher_confirm:
-            self.channel.confirm_delivery(self.on_confirmation)
+            self.channel.confirm_delivery(callback=self.on_confirmation)
         self.callbacks.on_ready(self.name)
 
-    def on_channel_closed(self, _channel, reply_code, reply_text):
+    def on_channel_closed(self, _channel, closing_reason):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
         violates the protocol, such as re-declare an exchange or queue with
@@ -173,24 +177,29 @@ class Connection(state.State):
         to shutdown the object.
 
         :param pika.channel.Channel _channel: The AMQP Channel
-        :param int reply_code: The AMQP reply code
-        :param str reply_text: The AMQP reply text
+        :param pika.exceptions.ChannelClosed closing_reason: The channel
+            closed exception
 
         """
         del self.channel
+        reply_code = closing_reason.reply_code
+        reply_text = closing_reason.reply_text
+
         if reply_code <= 0 or reply_code == 404:
             LOGGER.error('Channel Error (%r): %s',
                          reply_code, reply_text or 'unknown')
             self.on_failure()
         elif self.is_shutting_down:
             LOGGER.debug('Connection %s closing', self.name)
-            self.handle.close()
+            self.connection.close()
         elif self.is_running:
             LOGGER.warning('Connection %s channel was closed: (%s) %s',
                            self.name, reply_code, reply_text)
+
             try:
-                self.handle.channel(self.on_channel_open)
-            except exceptions.ConnectionClosed as error:
+                self.connection.channel(on_open_callback=self.on_channel_open)
+            except (exceptions.ConnectionWrongStateError,
+                    exceptions.ConnectionClosed) as error:
                 LOGGER.warning('Error raised while creating new channel: %s',
                                error)
                 self.on_failure()
@@ -201,18 +210,33 @@ class Connection(state.State):
         LOGGER.info('Connection failure, terminating connection')
         self.set_state(self.STATE_CLOSED)
         try:
-            self.handle.close()
-        except AttributeError:
+            self.connection.close()
+        except (AttributeError, exceptions.ConnectionWrongStateError):
             pass
-        del self.handle
+        del self.connection
         self.callbacks.on_connection_failure(self.name)
 
     def consume(self, queue_name, no_ack, prefetch_count):
+        """Configure quality of service and issue Basic.Consume command
+
+        :param str queue: The queue to consume from. Use the empty string to
+            specify the most recent server-named queue for this channel
+        :param bool no_ack: if set to True, automatic acknowledgement mode
+            will be used (see http://www.rabbitmq.com/confirms.html).
+            This corresponds with the 'no_ack' parameter in the basic.consume
+            AMQP 0.9.1 method
+        :param int prefetch_count: Specifies a prefetch window in terms of whole
+            messages.
+
+        """
         self.set_state(self.STATE_ACTIVE)
-        self.channel.basic_qos(self.on_qos_set, 0, prefetch_count, False)
-        self.channel.basic_consume(consumer_callback=self.on_delivery,
-                                   queue=queue_name,
-                                   no_ack=no_ack,
+        self.channel.basic_qos(callback=self.on_qos_set,
+                               prefetch_size=0,
+                               prefetch_count=prefetch_count,
+                               global_qos=False)
+        self.channel.basic_consume(queue=queue_name,
+                                   on_message_callback=self.on_delivery,
+                                   auto_ack=no_ack,
                                    consumer_tag=self.consumer_tag)
 
     def on_qos_set(self, frame):
@@ -272,10 +296,10 @@ class Connection(state.State):
             pika.PlainCredentials(
                 self.config.get('user', 'guest'),
                 self.config.get('password', self.config.get('pass', 'guest'))),
-            ssl=self.config.get('ssl', False),
+            ssl_options=self.config.get('ssl_options'),
             frame_max=self.config.get('frame_max', spec.FRAME_MAX_SIZE),
             socket_timeout=self.config.get('socket_timeout', 10),
-            heartbeat_interval=self.config.get(
+            heartbeat=self.config.get(
                 'heartbeat_interval', self.HB_INTERVAL))
 
 

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,5 +1,5 @@
 helper>=2.5.0,<3
-pika==0.13.1
+pika>=1.2.0,<3
 psutil
 pyyaml>=5.3.1,<6
 tornado

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='rejected',
-    version='3.21.1',
+    version='3.22.0',
     description='Rejected is a Python RabbitMQ Consumer Framework and '
                 'Controller Daemon',
     long_description=open('README.rst').read(),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -37,6 +37,16 @@ class TestProcess(test_state.TestState):
                 'user': 'guest',
                 'pass': 'guest',
                 'vhost': '/'
+            },
+            'MockRemoteSSLConnection': {
+                'host': 'remotehost',
+                'port': 5672,
+                'user': 'guest',
+                'pass': 'guest',
+                'vhost': '/',
+                'ssl_options': {
+                    'prototcol': 2,
+                }
             }
         },
         'Consumers': {
@@ -59,6 +69,14 @@ class TestProcess(test_state.TestState):
                 'min': 1,
                 'max': 2,
                 'queue': 'mock_you'
+            },
+            'MockConsumer3': {
+                'consumer': 'mock_consumer.MockConsumer',
+                'connections': ['MockRemoteSSLConnection'],
+                'config': {'num_value': 50},
+                'min': 1,
+                'max': 2,
+                'queue': 'mock_you2'
             }
         }
     }
@@ -208,6 +226,20 @@ class TestProcess(test_state.TestState):
         self.assertEqual(
             mock_process.qos_prefetch,
             self.config['Consumers']['MockConsumer']['qos_prefetch'])
+
+    def test_setup_with_ssl_connection(self):
+        self.mock_args['consumer_name'] = 'MockConsumer3'
+        mock_process = self.mock_setup()
+
+        conn = mock_process.connections['MockRemoteSSLConnection'].connection
+        self.assertTrue(bool(conn.params.ssl_options))
+
+    def test_setup_with_non_ssl_connection(self):
+        self.mock_args['consumer_name'] = 'MockConsumer2'
+        mock_process = self.mock_setup()
+
+        conn = mock_process.connections['MockRemoteConnection'].connection
+        self.assertFalse(bool(conn.params.ssl_options))
 
     def test_is_idle_state_processing(self):
         self._obj.state = self._obj.STATE_PROCESSING


### PR DESCRIPTION
- Update kwargs to basic_qos call since parameter names and order changed.
- Update kwargs to basic_consume call since parameter names and order changed.
- Update on_channel_closed callback to expect the `closing_reason` since the reply_code and reply_text parameters were moved to attributes of the ChannelClosed exception.
- Set the callback as a kwarg for channel.confirm_delivery since a new parameter was introduced.
- Renamed `self.handle` to `self.connection` in Connection class for reference to pika.tornado_connection.TornadoConnection.
- Add handling for new `ConnectionWrongStateError` when closing a channel or connection.
- Add support for `ssl_options` config parameters and deprecate `ssl` since it is no longer supported.
- Bump to rejected 3.22