### PR TITLE
Catch AttributeError when AMQPHeartbeatTimeout

### DIFF
--- a/rejected/process.py
+++ b/rejected/process.py
@@ -183,8 +183,12 @@ class Connection(state.State):
 
         """
         del self.channel
-        reply_code = closing_reason.reply_code
-        reply_text = closing_reason.reply_text
+        try:
+            reply_code = closing_reason.reply_code
+            reply_text = closing_reason.reply_text
+        except AttributeError:
+            reply_code = 0
+            reply_text = 'unknown'
 
         if reply_code <= 0 or reply_code == 404:
             LOGGER.error('Channel Error (%r): %s',


### PR DESCRIPTION
When pika throws a `AMQPHeartbeatTimeout` this object gets set as the `closing_reason` in the `on_channel_closed` method. The `AMQPHeartbeatTimeout` does not have attributes for `reply_code` or `reply_text` so when these are attempted to accessed a `AttributeError` is thrown, causing an unhandled exception.

The end result of this unhandled exception is that the consumer is disconnected (b/c of the heartbeat timeout) but doesn't know this, causing it to just hang idle until it is manually restarted. Capturing the exception here and setting the `reply_code` and `reply_text` to sane defaults (namely, `0` and `unknown` like is checked for below) will allow rejected to call its `on_failure` handler, and close the connection properly.