### PR TITLE
Fix unset status_text error

### DIFF
--- a/rejected/process.py
+++ b/rejected/process.py
@@ -131,7 +131,7 @@ class Connection(state.State):
         LOGGER.error('Connection %s failure %r %r', self.name, args, kwargs)
         self.on_failure()
 
-    def on_closed(self, _connection, status_code, status_text):
+    def on_closed(self, _connection, status_code, status_text='unknown'):
         if self.is_connecting:
             LOGGER.error('Connection %s failure while connecting (%s): %s',
                          self.name, status_code, status_text)


### PR DESCRIPTION
Addresses calls to on_closed() which do not set the status_text args param.

Error:
`File "/usr/local/lib/python3.9/site-packages/pika/callback.py", line 233, in process callback(*args, **keywords) ", "TypeError: on_closed() missing 1 required positional argument: 'status_text' `