### PR TITLE
Loosen pyyaml pin to allow version 6

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+3.22.3
+------
+- Loosen pyyaml for v6+ and Python 3.12
+
+3.22.2
+------
+- Update on closed callback to receive an exception for Pika 1.3
+
 3.22.1
 ------
 - Handle AMQPHeartbeatTimeout gracefully - `#45 <https://github.com/gmr/rejected/pull/45>`_ - `joshehlinger <https://github.com/joshehlinger>`_

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -224,8 +224,8 @@ class Connection(state.State):
     def consume(self, queue_name, no_ack, prefetch_count):
         """Configure quality of service and issue Basic.Consume command
 
-        :param str queue: The queue to consume from. Use the empty string to
-            specify the most recent server-named queue for this channel
+        :param str queue_name: The queue to consume from. Use the empty string
+            to specify the most recent server-named queue for this channel
         :param bool no_ack: if set to True, automatic acknowledgement mode
             will be used (see http://www.rabbitmq.com/confirms.html).
             This corresponds with the 'no_ack' parameter in the basic.consume

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,5 +1,5 @@
 helper>=2.5.0,<3
 pika>=1.2.0,<3
 psutil
-pyyaml>=5.3.1,<6
+pyyaml>=5.3.1,<7
 tornado

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='rejected',
-    version='3.22.2',
+    version='3.22.3',
     description='Rejected is a Python RabbitMQ Consumer Framework and '
                 'Controller Daemon',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
- Allow pyyaml version up to <7
- Fix param name in method docblock from a previous commit.
- Bump version to 3.22.3