### PR TITLE
Update on channel and connection callback params

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.22.4
+------
+- Update on channel and connection callback to accept any `*args, **kwargs` to accomodate Pika updates. Since arguments are not used, except logging only.
+- Update unit tests that may be broken due to asyncio / tornado updates.
+
 3.22.3
 ------
 - Loosen pyyaml for v6+ and Python 3.12

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -131,23 +131,23 @@ class Connection(state.State):
         LOGGER.error('Connection %s failure %r %r', self.name, args, kwargs)
         self.on_failure()
 
-    def on_closed(self, _connection, error):
+    def on_closed(self, *args, **kwargs):
         if self.is_connecting:
-            LOGGER.error('Connection %s failure while connecting (%s)',
-                         self.name, error)
+            LOGGER.error('Connection %s failure while connecting: (%r %r)',
+                         self.name, args, kwargs)
             self.on_failure()
         elif not self.is_closed:
             self.set_state(self.STATE_CLOSED)
-            LOGGER.info('Connection %s closed (%s)', self.name, error)
+            LOGGER.info('Connection %s closed (%r %r)', self.name, args, kwargs)
             self.callbacks.on_closed(self.name)
 
-    def on_blocked(self, frame):
-        LOGGER.warning('Connection %s is blocked: %r', frame)
+    def on_blocked(self, *args, **kwargs):
+        LOGGER.warning('Connection %s is blocked: (%r %r)', args, kwargs)
         self.blocked = True
         self.callbacks.on_blocked(self.name)
 
-    def on_unblocked(self, frame):
-        LOGGER.warning('Connection %s is unblocked: %r', frame)
+    def on_unblocked(self, *args, **kwargs):
+        LOGGER.warning('Connection %s is unblocked: (%r %r)', args, kwargs)
         self.blocked = False
         self.callbacks.on_unblocked(self.name)
 
@@ -252,11 +252,9 @@ class Connection(state.State):
         """
         LOGGER.debug('Connection %s QoS was set: %r', self.name, frame)
 
-    def on_consumer_cancelled(self, frame):
+    def on_consumer_cancelled(self, *args, **kwargs):
         """Invoked by pika when a ``Basic.Cancel`` or ``Basic.CancelOk``
         is received.
-
-        :param pika.frame.Frame frame: The QoS Frame
 
         """
         LOGGER.info('Connection %s consumer has been cancelled', self.name)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='rejected',
-    version='3.22.3',
+    version='3.22.4',
     description='Rejected is a Python RabbitMQ Consumer Framework and '
                 'Controller Daemon',
     long_description=open('README.rst').read(),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -95,74 +95,114 @@ class ConsumerReceiveTests(testing.AsyncTestCase):
 
 class ConsumerPropertyTests(testing.AsyncTestCase):
 
-    @gen.coroutine
     def setUp(self):
         super(ConsumerPropertyTests, self).setUp()
         self.config = {'foo': 'bar', 'baz': 1, 'qux': True}
         self.message = data.Message('mock', mocks.CHANNEL, mocks.METHOD,
                                     mocks.PROPERTIES, mocks.BODY, False)
         self.measurement = data.Measurement()
+
+    @gen.coroutine
+    def run_consumer(self):
         self.obj = TestConsumer(self.config, None)
         yield self.obj.execute(self.message, self.measurement)
 
+    @testing.gen_test
     def test_app_id_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.app_id, mocks.PROPERTIES.app_id)
 
+    @testing.gen_test
     def test_body_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.body, mocks.BODY)
 
+    @testing.gen_test
     def test_settings_property(self):
+        yield self.run_consumer()
         self.assertDictEqual(self.obj.settings, self.config)
 
+    @testing.gen_test
     def test_content_encoding_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.content_encoding,
                          mocks.PROPERTIES.content_encoding)
 
+    @testing.gen_test
     def test_content_type_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.content_type, mocks.PROPERTIES.content_type)
 
+    @testing.gen_test
     def test_correlation_id_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.correlation_id,
                          mocks.PROPERTIES.correlation_id)
 
+    @testing.gen_test
     def test_exchange_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.exchange, mocks.METHOD.exchange)
 
+    @testing.gen_test
     def test_expiration_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.expiration, mocks.PROPERTIES.expiration)
 
+    @testing.gen_test
     def test_headers_property(self):
+        yield self.run_consumer()
         self.assertDictEqual(self.obj.headers, mocks.PROPERTIES.headers)
 
+    @testing.gen_test
     def test_message_id_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.message_id, mocks.PROPERTIES.message_id)
 
+    @testing.gen_test
     def test_name_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.name, self.obj.__class__.__name__)
 
+    @testing.gen_test
     def test_priority_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.priority, mocks.PROPERTIES.priority)
 
+    @testing.gen_test
     def test_properties_property(self):
+        yield self.run_consumer()
         self.assertDictEqual(self.obj.properties,
                              dict(data.Properties(mocks.PROPERTIES)))
 
+    @testing.gen_test
     def test_redelivered_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.redelivered, mocks.METHOD.redelivered)
 
+    @testing.gen_test
     def test_reply_to_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.reply_to, mocks.PROPERTIES.reply_to)
 
+    @testing.gen_test
     def test_routing_key_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.routing_key, mocks.METHOD.routing_key)
 
+    @testing.gen_test
     def test_message_type_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.message_type, mocks.PROPERTIES.type)
 
+    @testing.gen_test
     def test_timestamp_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.timestamp, mocks.PROPERTIES.timestamp)
 
+    @testing.gen_test
     def test_user_id_property(self):
+        yield self.run_consumer()
         self.assertEqual(self.obj.user_id, mocks.PROPERTIES.user_id)
 
 
@@ -171,16 +211,18 @@ class TestSmartConsumer(consumer.SmartConsumer):
         pass
 
 
-class TestSmartConsumerWithJSON(unittest.TestCase):
+class TestSmartConsumerWithJSON(testing.AsyncTestCase):
 
     def setUp(self):
+        super(TestSmartConsumerWithJSON, self).setUp()
         self.body = {'foo': 'bar', 'baz': 1, 'qux': True}
         self.message = data.Message('mock', mocks.CHANNEL, mocks.METHOD,
                                     mocks.PROPERTIES, json.dumps(self.body),
                                     False)
         self.measurement = data.Measurement()
+
+    @testing.gen_test
+    def test_message_body_property(self):
         self.obj = TestSmartConsumer({}, None)
         self.obj.execute(self.message, self.measurement)
-
-    def test_message_body_property(self):
         self.assertDictEqual(self.obj.body, self.body)


### PR DESCRIPTION
- Update on channel and connection callback to accept any `*args, **kwargs` to accomodate Pika updates. Since arguments are not used, except logging only.
- Update unit tests that may be broken due to asyncio / tornado updates.