### PR TITLE
Shutdown message connection is not running

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Changelog
 ------
 - Update on channel and connection callback to accept any `*args, **kwargs` to accomodate Pika updates. Since arguments are not used, except logging only.
 - Update unit tests that may be broken due to asyncio / tornado updates.
+- Shutdown message connection it we detect it's not running to allow the MCP to attempt reconnect.
 
 3.22.3
 ------

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -435,7 +435,9 @@ class Process(multiprocessing.Process, state.State):
         if not self.connections[message.connection].is_running:
             LOGGER.warning('Can not ack message, disconnected from RabbitMQ')
             self.counters[self.CLOSED_ON_COMPLETE] += 1
+            self.connections[message.connection].shutdown()
             return
+
         LOGGER.debug('Acking %s', message.delivery_tag)
         message.channel.basic_ack(delivery_tag=message.delivery_tag)
         self.counters[self.ACKED] += 1
@@ -826,6 +828,7 @@ class Process(multiprocessing.Process, state.State):
         if not self.connections[message.connection].is_running:
             LOGGER.warning('Can not nack message, disconnected from RabbitMQ')
             self.counters[self.CLOSED_ON_COMPLETE] += 1
+            self.connections[message.connection].shutdown()
             return
 
         LOGGER.warning('Rejecting message %s %s requeue', message.delivery_tag,


### PR DESCRIPTION
- Shutdown message connection it we detect it's not running to allow the MCP to attempt reconnect
- Add unit tests to cover changes
- Update Changelog for `3.22.4` since it's unreleased.