### PR TITLE
Fix message-processing lifecycle, shutdown, and reconnect bugs

### DIFF
--- a/rejected/connection.py
+++ b/rejected/connection.py
@@ -67,6 +67,9 @@ class Connection(state.State):
         return self.is_stopped
 
     def shutdown(self) -> None:
+        if self.is_closed:
+            LOGGER.debug('Connection %s is already closed', self.name)
+            return
         if self.is_shutting_down:
             LOGGER.debug('Connection %s is already shutting down', self.name)
             return
@@ -84,7 +87,10 @@ class Connection(state.State):
         elif self.channel:
             self.channel.close()
         else:
-            self.connection.close()
+            try:
+                self.connection.close()
+            except (AttributeError, pika.exceptions.ConnectionWrongStateError):
+                pass
 
     def on_open(
         self, connection: asyncio_connection.AsyncioConnection
@@ -241,7 +247,6 @@ class Connection(state.State):
             self.connection.close()
         except (AttributeError, pika.exceptions.ConnectionWrongStateError):
             pass
-        del self.connection
         self.callbacks.on_connection_failure(self.name)
 
     def consume(
@@ -380,6 +385,7 @@ class Connection(state.State):
                 protocol,
             )
             context = ssl.SSLContext(protocol)
+            context.check_hostname = True
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_default_certs()
 

--- a/rejected/connection.py
+++ b/rejected/connection.py
@@ -85,7 +85,10 @@ class Connection(state.State):
                 self.consumer_tag, self.on_consumer_cancelled
             )
         elif self.channel:
-            self.channel.close()
+            try:
+                self.channel.close()
+            except (AttributeError, pika.exceptions.ChannelWrongStateError):
+                pass
         else:
             try:
                 self.connection.close()

--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -167,7 +167,7 @@ class _Consumer:
         # correct per-message when processing concurrently. The contextvar
         # is what the logging adapter reads, isolating it per asyncio task.
         cid = msg.correlation_id or msg.message_id or str(uuid.uuid4())
-        if msg.correlation_id is None:
+        if not msg.correlation_id:
             msg.correlation_id = cid
         self._correlation_id = cid
         log.correlation_id.set(cid)
@@ -313,7 +313,10 @@ class _Consumer:
 
     @property
     def correlation_id(self) -> str | None:
-        return self._correlation_id
+        # Prefer the task-local contextvar so concurrent FunctionalConsumer
+        # messages don't read another in-flight message's id via shared
+        # instance state.
+        return log.correlation_id.get() or self._correlation_id
 
     @property
     def name(self) -> str:

--- a/rejected/consumer.py
+++ b/rejected/consumer.py
@@ -85,6 +85,7 @@ class _Consumer:
         self._process = process
         self._settings = settings
         self._initialized = False
+        self._init_lock: asyncio.Lock | None = None
 
         self._logger = logging.getLogger(
             settings.get('_import_module', __name__)
@@ -128,9 +129,7 @@ class _Consumer:
         The result is stored on ``ctx.result``.
 
         """
-        if not self._initialized:
-            await self.initialize()
-            self._initialized = True
+        await self._ensure_initialized()
 
         result = self._pre_execute(ctx)
         if result is not None:
@@ -138,6 +137,20 @@ class _Consumer:
             return
 
         ctx.result = await self._run_consumer(ctx)
+
+    async def _ensure_initialized(self) -> None:
+        """Run :meth:`initialize` exactly once, even when multiple messages
+        are processed concurrently.
+
+        """
+        if self._initialized:
+            return
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
+        async with self._init_lock:
+            if not self._initialized:
+                await self.initialize()
+                self._initialized = True
 
     def _pre_execute(
         self, ctx: models.ProcessingContext
@@ -150,10 +163,14 @@ class _Consumer:
         """
         msg = ctx.message
 
-        # Ensure correlation ID
-        self._correlation_id = (
-            msg.correlation_id or msg.message_id or str(uuid.uuid4())
-        )
+        # Ensure correlation ID, carrying it on the message so it stays
+        # correct per-message when processing concurrently. The contextvar
+        # is what the logging adapter reads, isolating it per asyncio task.
+        cid = msg.correlation_id or msg.message_id or str(uuid.uuid4())
+        if msg.correlation_id is None:
+            msg.correlation_id = cid
+        self._correlation_id = cid
+        log.correlation_id.set(cid)
 
         if msg.type:
             self.set_sentry_context('type', msg.type)
@@ -180,11 +197,12 @@ class _Consumer:
             msg.headers or {}
         ):
             raw_count = msg.headers[_PROCESSING_EXCEPTIONS]
-            count = (
-                int(raw_count)
-                if isinstance(raw_count, (int, float, str))
-                else 0
-            )
+            try:
+                count = int(raw_count)  # type: ignore[arg-type]
+            except (ValueError, TypeError):
+                # Unparseable counts are treated as 0 so the message keeps
+                # flowing rather than looping forever on a ValueError.
+                count = 0
             if count >= self._error_max_retry:
                 self.logger.warning(
                     'Dropping message with %i deaths due to ERROR_MAX_RETRY',
@@ -219,7 +237,6 @@ class _Consumer:
             await handler()
         except KeyboardInterrupt:
             self.logger.debug('CTRL-C')
-            self._process.reject(ctx, True)
             self._process.stop()
             return models.Result.MESSAGE_REQUEUE
         except pika_exceptions.ChannelClosed as error:
@@ -474,11 +491,28 @@ class _Consumer:
         headers['X-Original-Exchange'] = msg.exchange or ''
         headers['X-Original-Queue'] = self._process.queue_name
         headers.update(extra_headers)
+        # Preserve the original AMQP properties (content type/encoding,
+        # type, correlation id, priority, expiration, etc.) so downstream
+        # error/drop pipelines can still decode and route the message.
+        properties = pika.BasicProperties(
+            app_id=msg.app_id,
+            content_encoding=msg.content_encoding,
+            content_type=msg.content_type,
+            correlation_id=msg.correlation_id,
+            delivery_mode=msg.delivery_mode,
+            expiration=msg.expiration,
+            message_id=msg.message_id,
+            priority=msg.priority,
+            reply_to=msg.reply_to,
+            type=msg.type,
+            user_id=msg.user_id,
+            headers=headers,
+        )
         ctx.channel.basic_publish(
             exchange=exchange,
             routing_key=msg.routing_key or '',
             body=ctx.raw_body or msg.body,
-            properties=pika.BasicProperties(headers=headers),
+            properties=properties,
         )
 
     def _republish_dropped_message(
@@ -504,7 +538,10 @@ class _Consumer:
             headers['X-Processing-Exception'] = error
         msg_headers = ctx.message.headers or {}
         raw_prev = msg_headers.get(_PROCESSING_EXCEPTIONS, 0)
-        prev = int(raw_prev) if isinstance(raw_prev, (int, float, str)) else 0
+        try:
+            prev = int(raw_prev)  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            prev = 0
         headers[_PROCESSING_EXCEPTIONS] = prev + 1
         self._republish(ctx, self._error_exchange or '', headers)
 
@@ -540,26 +577,40 @@ class Consumer(_Consumer):
         """Called after processing completes."""
         pass
 
-    async def _run_consumer(
-        self, ctx: models.ProcessingContext
-    ) -> models.Result:
+    async def execute(self, ctx: models.ProcessingContext) -> None:
+        """Serialize the entire message lifecycle behind the lock.
+
+        Pre-validation (which sets ``self._correlation_id`` and other
+        per-message state) must run inside the lock so a second message
+        can not clobber it while the first is still processing.
+
+        """
+        await self._ensure_initialized()
         if self._lock is None:
             self._lock = asyncio.Lock()
         async with self._lock:
-            self._context = ctx
+            result = self._pre_execute(ctx)
+            if result is not None:
+                ctx.result = result
+                return
+            ctx.result = await self._run_consumer(ctx)
+
+    async def _run_consumer(
+        self, ctx: models.ProcessingContext
+    ) -> models.Result:
+        self._context = ctx
+        self._message_body = _UNSET
+        try:
+            return await self._handle_execution(ctx, self._process_standard)
+        finally:
+            await self.on_finish()
+            self._context = None
             self._message_body = _UNSET
-            try:
-                return await self._handle_execution(
-                    ctx, self._process_standard
-                )
-            finally:
-                await self.on_finish()
-                self._context = None
-                self._message_body = _UNSET
 
     async def _process_standard(self) -> None:
         await self.prepare()
         await self.process()
+        await self.finish()
 
     # --- Quick-access properties (read from self._context) ---
 

--- a/rejected/log.py
+++ b/rejected/log.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import typing
+
+# Per-task correlation id. Set for each message in _Consumer._pre_execute;
+# because each message is processed in its own asyncio task, the value is
+# isolated per task and does not clobber concurrent messages.
+correlation_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    'correlation_id', default=None
+)
 
 
 class CorrelationFilter(logging.Formatter):
@@ -36,7 +44,8 @@ class CorrelationAdapter(logging.LoggerAdapter[logging.Logger]):
         self, msg: str, kwargs: typing.MutableMapping[str, typing.Any]
     ) -> tuple[str, typing.MutableMapping[str, typing.Any]]:
         kwargs['extra'] = {
-            'correlation_id': self.consumer.correlation_id,
+            'correlation_id': correlation_id.get()
+            or self.consumer.correlation_id,
             'consumer': self.consumer.name,
         }
         return msg, kwargs

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -117,8 +117,9 @@ class Process(multiprocessing.Process, state.State):
         self.state_start = time.time()
         self.statsd: statsd.Client | None = None
 
-        # Concurrent message tracking
-        self._in_flight: dict[int, models.ProcessingContext] = {}
+        # Concurrent message tracking, keyed by (connection_name,
+        # delivery_tag) so tags from different connections do not collide.
+        self._in_flight: dict[tuple[str, int], models.ProcessingContext] = {}
         self._tasks: set[asyncio.Task[typing.Any]] = set()
 
         # Cumulative counts for stats reporting
@@ -140,6 +141,11 @@ class Process(multiprocessing.Process, state.State):
         :param ctx: The processing context containing the message
 
         """
+        if ctx.message.returned or ctx.message.delivery_tag is None:
+            LOGGER.debug('Skipping ack for returned message')
+            ctx.measurement.set_tag(self.ACKED, True)
+            return
+
         if not ctx.connection.is_running:
             LOGGER.warning('Can not ack message, disconnected from RabbitMQ')
             ctx.measurement.set_tag(self.CLOSED_ON_COMPLETE, True)
@@ -275,9 +281,10 @@ class Process(multiprocessing.Process, state.State):
             return
 
         tag = (
+            ctx.connection.name,
             ctx.message.delivery_tag
             if ctx.message.delivery_tag is not None
-            else id(ctx.message)
+            else id(ctx.message),
         )
         if not self._in_flight and self.is_idle:
             self.set_state(self.STATE_PROCESSING)
@@ -296,6 +303,7 @@ class Process(multiprocessing.Process, state.State):
             except codecs.DecodeError as error:
                 LOGGER.error('Failed to decode message body: %s', error)
                 ctx.result = models.Result.MESSAGE_EXCEPTION
+                self._in_flight.pop(tag, None)
                 self.on_processed(ctx)
                 return
 
@@ -345,7 +353,9 @@ class Process(multiprocessing.Process, state.State):
     def on_connection_closed(self, name: str) -> None:
         if self.is_running:
             LOGGER.warning('Connection %s was closed, reconnecting', name)
-            self.connections[name].connect()
+            self.connections[name].connection = self.connections[
+                name
+            ].connect()
             return
 
         ready = all(c.is_closed for c in self.connections.values())
@@ -355,6 +365,18 @@ class Process(multiprocessing.Process, state.State):
     def on_connection_failure(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
+        name = args[0] if args else None
+        # A terminal channel/connection error while actively processing must
+        # not leave a zombie: reconnect so the process can keep working.
+        if self.state == self.STATE_PROCESSING and name in self.connections:
+            LOGGER.warning(
+                'Connection %s failed while processing, reconnecting', name
+            )
+            self.connections[name].connection = self.connections[
+                name
+            ].connect()
+            return
+
         ready = all(c.is_closed for c in self.connections.values())
         LOGGER.warning(
             'Connection failure while %s - Ready to stop: %r',
@@ -372,14 +394,21 @@ class Process(multiprocessing.Process, state.State):
     def on_connection_ready(self, name: str) -> None:
         LOGGER.debug('Connection %s indicated it is ready', name)
         self.consumer.set_channel(name, self.connections[name].channel)
-        if all(c.is_idle for c in self.connections.values()):
-            for key in self.connections.keys():
-                if self.connections[key].should_consume:
-                    self.connections[key].consume(
-                        self.queue_name, self.no_ack, self.qos_prefetch
-                    )
-            if self.is_connecting:
+        if self.is_connecting:
+            # Initial startup: wait for every connection before consuming.
+            if all(c.is_idle for c in self.connections.values()):
+                for key in self.connections.keys():
+                    if self.connections[key].should_consume:
+                        self.connections[key].consume(
+                            self.queue_name, self.no_ack, self.qos_prefetch
+                        )
                 self.set_state(self.STATE_IDLE)
+        elif self.connections[name].should_consume:
+            # A reconnecting connection became ready: re-issue its consume
+            # rather than waiting on all connections to be idle again.
+            self.connections[name].consume(
+                self.queue_name, self.no_ack, self.qos_prefetch
+            )
 
     def on_connection_blocked(self, name: str) -> None:
         LOGGER.warning('Connection %s blocked', name)
@@ -606,9 +635,29 @@ class Process(multiprocessing.Process, state.State):
         :param frame _unused_frame: The python frame the signal was received at
 
         """
+        # Do the actual work on the event loop; a Unix signal handler must
+        # not touch pika/loop state directly.
+        if self.ioloop:
+            self.ioloop.call_soon_threadsafe(self._report_stats)
+        signal.siginterrupt(signal.SIGPROF, False)
+
+    def _report_stats(self) -> None:
+        """Push a stats snapshot onto the MCP queue from the event loop."""
         self.stats_queue.put(self.report_stats(), True)
         self.last_stats_time = time.time()
-        signal.siginterrupt(signal.SIGPROF, False)
+
+    def on_sigabrt(
+        self, signum: int, _unused_frame: types.FrameType | None = None
+    ) -> None:
+        """Handle SIGABRT by scheduling stop() on the event loop so all pika
+        interaction happens from a loop callback rather than the signal
+        handler.
+
+        """
+        if self.ioloop:
+            self.ioloop.call_soon_threadsafe(self.stop, signum)
+        else:
+            self.stop(signum)
 
     def on_startup_error(self, error: str) -> None:
         """Invoked when a pre-condition for starting the consumer has failed.
@@ -627,8 +676,18 @@ class Process(multiprocessing.Process, state.State):
         :param requeue: Specify if the message should be re-queued
 
         """
+        if ctx.message.returned or ctx.message.delivery_tag is None:
+            LOGGER.debug('Skipping nack for returned message')
+            ctx.measurement.set_tag(self.NACKED, True)
+            ctx.measurement.set_tag(self.REQUEUED, requeue)
+            return
+
         if self.no_ack:
-            raise RuntimeError('Can not reject messages when ack is False')
+            # Auto-ack mode: there is nothing to nack on the broker, but the
+            # metrics still reflect the intended disposition.
+            ctx.measurement.set_tag(self.NACKED, True)
+            ctx.measurement.set_tag(self.REQUEUED, requeue)
+            return
 
         if not ctx.connection.is_running:
             LOGGER.warning('Can not nack message, disconnected from RabbitMQ')
@@ -727,6 +786,25 @@ class Process(multiprocessing.Process, state.State):
                 self.ioloop.run_forever()
             except KeyboardInterrupt:
                 LOGGER.warning('CTRL-C while waiting for clean shutdown')
+            finally:
+                self._complete_pending_tasks()
+
+    def _complete_pending_tasks(self) -> None:
+        """Run any tasks scheduled during shutdown (consumer.shutdown and
+        codec.close) to completion, since the loop was stopped before they
+        had a chance to run.
+
+        """
+        if not self.ioloop or self.ioloop.is_running():
+            return
+        pending = [
+            task for task in asyncio.all_tasks(self.ioloop) if not task.done()
+        ]
+        if pending:
+            LOGGER.debug('Completing %i pending task(s)', len(pending))
+            self.ioloop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
 
     def send_exception_to_sentry(
         self,
@@ -828,7 +906,7 @@ class Process(multiprocessing.Process, state.State):
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
         signal.signal(signal.SIGPROF, self.on_sigprof)
-        signal.signal(signal.SIGABRT, self.stop)
+        signal.signal(signal.SIGABRT, self.on_sigabrt)
 
         signal.siginterrupt(signal.SIGPROF, False)
         signal.siginterrupt(signal.SIGABRT, False)
@@ -839,8 +917,11 @@ class Process(multiprocessing.Process, state.State):
         if not self.is_shutting_down:
             self.set_state(self.STATE_SHUTTING_DOWN)
         for name in self.connections:
-            if self.connections[name].is_running:
-                self.connections[name].shutdown()
+            conn = self.connections[name]
+            # Also shut down connections still connecting, otherwise their
+            # in-progress open blocks shutdown from ever completing.
+            if conn.is_running or conn.is_connecting:
+                conn.shutdown()
 
     def stop(
         self, signum: int | None = None, _unused: types.FrameType | None = None
@@ -863,16 +944,18 @@ class Process(multiprocessing.Process, state.State):
             LOGGER.warning('Stop requested but already waiting to shut down')
             return
 
-        # Stop consuming and close AMQP connections
-        self.shutdown_connections()
-
-        # Wait until the consumer has finished processing to shutdown
+        # If we are mid-processing, wait for in-flight messages to drain
+        # before tearing down connections. on_processed calls
+        # shutdown_connections once _in_flight is empty.
         if self.is_processing:
             LOGGER.info('Waiting for consumer to finish processing')
             self.set_state(self.STATE_STOP_REQUESTED)
             if signum == signal.SIGTERM:
                 signal.siginterrupt(signal.SIGTERM, False)
             return
+
+        # Stop consuming and close AMQP connections
+        self.shutdown_connections()
 
     def stop_consumer(self) -> None:
         """Stop the consumer object and allow it to do a clean shutdown if it

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,99 @@
+"""Tests for rejected.connection"""
+
+import ssl
+import typing
+import unittest
+from unittest import mock
+
+from rejected import config as config_module
+from rejected import connection as connection_mod
+from rejected import models
+
+_CONFIG_RAW: dict[str, typing.Any] = {
+    'Connections': {
+        'MockConnection': {
+            'host': 'localhost',
+            'port': 5672,
+            'user': 'guest',
+            'pass': 'guest',
+            'vhost': '/',
+        },
+        'MockSSLConnection': {
+            'host': 'remotehost',
+            'port': 5672,
+            'user': 'guest',
+            'pass': 'guest',
+            'vhost': '/',
+            'ssl_options': {'protocol': ssl.PROTOCOL_TLS},
+        },
+    }
+}
+
+
+def _config() -> config_module.Config:
+    return config_module.Config.model_validate(_CONFIG_RAW)
+
+
+def _callbacks() -> models.Callbacks:
+    return models.Callbacks(
+        on_ready=mock.Mock(),
+        on_connection_failure=mock.Mock(),
+        on_closed=mock.Mock(),
+        on_blocked=mock.Mock(),
+        on_unblocked=mock.Mock(),
+        on_confirmation=mock.Mock(),
+        on_delivery=mock.Mock(),
+        on_return=mock.Mock(),
+    )
+
+
+def _make_connection(
+    name: str = 'MockConnection',
+) -> connection_mod.Connection:
+    cfg = _config().connections[name]
+    with mock.patch.object(
+        connection_mod.asyncio_connection, 'AsyncioConnection'
+    ):
+        return connection_mod.Connection(
+            name, cfg, 'consumer', True, False, _callbacks()
+        )
+
+
+class ShutdownTests(unittest.TestCase):
+    def test_shutdown_is_noop_when_closed(self) -> None:
+        """#74 shutting down an already-closed connection is a no-op."""
+        conn = _make_connection()
+        conn.set_state(conn.STATE_CLOSED)
+        conn.connection = mock.Mock()
+        conn.channel = None
+        conn.shutdown()
+        conn.connection.close.assert_not_called()
+        self.assertTrue(conn.is_closed)
+
+    def test_shutdown_guards_connection_close(self) -> None:
+        """#74 a raising connection.close() is swallowed."""
+        conn = _make_connection()
+        conn.set_state(conn.STATE_CONNECTING)
+        conn.channel = None
+        conn.connection = mock.Mock()
+        conn.connection.close.side_effect = (
+            connection_mod.pika.exceptions.ConnectionWrongStateError()
+        )
+        conn.shutdown()  # must not raise
+
+    def test_on_failure_keeps_connection_attribute(self) -> None:
+        """#74 on_failure no longer deletes self.connection."""
+        conn = _make_connection()
+        conn.connection = mock.Mock()
+        conn.on_failure()
+        self.assertTrue(hasattr(conn, 'connection'))
+
+
+class SSLOptionsTests(unittest.TestCase):
+    def test_non_default_protocol_enables_hostname_check(self) -> None:
+        """#78 the legacy SSL path verifies the hostname."""
+        conn = _make_connection('MockSSLConnection')
+        opts = conn._ssl_options
+        assert opts is not None
+        self.assertTrue(opts.context.check_hostname)
+        self.assertEqual(opts.context.verify_mode, ssl.CERT_REQUIRED)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -326,11 +326,13 @@ class CorrelationTests(unittest.IsolatedAsyncioTestCase):
     async def test_correlation_isolated_per_message(self):
         """#81 concurrent messages do not clobber each other's id."""
         seen: dict[str, str | None] = {}
+        prop: dict[str, str | None] = {}
 
         class C(consumer.FunctionalConsumer):
             async def process(self, ctx):
                 await asyncio.sleep(0.01)
                 seen[ctx.message.correlation_id] = log.correlation_id.get()
+                prop[ctx.message.correlation_id] = self.correlation_id
 
         obj = C(config_module.Settings({}), None)
         ctx1 = _make_ctx(_make_message(correlation_id='a'))
@@ -338,6 +340,10 @@ class CorrelationTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.gather(obj.execute(ctx1), obj.execute(ctx2))
         self.assertEqual(seen['a'], 'a')
         self.assertEqual(seen['b'], 'b')
+        # The public property must also be task-local, not clobbered by
+        # the other in-flight message via shared instance state.
+        self.assertEqual(prop['a'], 'a')
+        self.assertEqual(prop['b'], 'b')
 
     async def test_initialize_called_once_concurrently(self):
         """#81 initialize() runs exactly once under concurrency."""

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,5 +1,6 @@
 """Tests for rejected.consumer"""
 
+import asyncio
 import datetime
 import typing
 import unittest
@@ -7,7 +8,7 @@ from unittest import mock
 
 from rejected import config as config_module
 from rejected import connection as connection_mod
-from rejected import consumer, exceptions, models
+from rejected import consumer, exceptions, log, models
 
 
 def _make_message(**kwargs: typing.Any) -> models.Message:
@@ -227,3 +228,131 @@ class ConsumerPropertyTests(unittest.IsolatedAsyncioTestCase):
     async def test_settings_accessible(self):
         obj = TestConsumer(config_module.Settings({'foo': 'bar'}), None)
         self.assertEqual(obj.settings.get('foo'), 'bar')
+
+
+class ConsumerLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_finish_is_called(self):
+        """#68 finish() runs after process() in the standard lifecycle."""
+        calls: list[str] = []
+
+        class LC(consumer.Consumer):
+            async def prepare(self):
+                calls.append('prepare')
+
+            async def process(self):
+                calls.append('process')
+
+            async def finish(self):
+                calls.append('finish')
+
+        obj = LC(config_module.Settings({}), None)
+        await obj.execute(_make_ctx())
+        self.assertEqual(calls, ['prepare', 'process', 'finish'])
+
+
+class RepublishPropertyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_processing_error_preserves_properties(self):
+        """#69 republished messages keep the original AMQP properties."""
+
+        class PC(consumer.Consumer):
+            async def process(self):
+                raise exceptions.ProcessingException('boom')
+
+        proc = mock.Mock()
+        proc.queue_name = 'q'
+        proc.sentry_client = None
+        obj = PC(config_module.Settings({}), proc)
+        msg = _make_message()
+        ctx = _make_ctx(msg)
+        await obj.execute(ctx)
+        self.assertEqual(ctx.result, models.Result.PROCESSING_EXCEPTION)
+        props = ctx.channel.basic_publish.call_args.kwargs['properties']
+        self.assertEqual(props.content_type, msg.content_type)
+        self.assertEqual(props.correlation_id, msg.correlation_id)
+        self.assertEqual(props.type, msg.type)
+        self.assertEqual(props.priority, msg.priority)
+        self.assertEqual(props.expiration, msg.expiration)
+
+
+class ProcessingExceptionsHeaderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_numeric_header_does_not_raise(self):
+        """#80 a non-numeric X-Processing-Exceptions header is tolerated."""
+
+        class MR(consumer.Consumer):
+            ERROR_MAX_RETRY = 3
+
+            async def process(self):
+                pass
+
+        obj = MR(config_module.Settings({}), None)
+        msg = _make_message(headers={'X-Processing-Exceptions': 'not-a-num'})
+        ctx = _make_ctx(msg)
+        await obj.execute(ctx)
+        self.assertEqual(ctx.result, models.Result.MESSAGE_ACK)
+
+
+class KeyboardInterruptTests(unittest.IsolatedAsyncioTestCase):
+    async def test_keyboard_interrupt_does_not_reject(self):
+        """#82 the KeyboardInterrupt handler no longer double-nacks."""
+
+        class KC(consumer.Consumer):
+            async def process(self):
+                raise KeyboardInterrupt()
+
+        proc = mock.Mock()
+        proc.sentry_client = None
+        obj = KC(config_module.Settings({}), proc)
+        ctx = _make_ctx()
+        await obj.execute(ctx)
+        proc.reject.assert_not_called()
+        proc.stop.assert_called_once()
+        self.assertEqual(ctx.result, models.Result.MESSAGE_REQUEUE)
+
+
+class CorrelationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_correlation_id_set_on_message(self):
+        """#81 a missing correlation id is generated and carried on ctx."""
+
+        class C(consumer.Consumer):
+            async def process(self):
+                pass
+
+        obj = C(config_module.Settings({}), None)
+        msg = _make_message(correlation_id=None, message_id=None)
+        ctx = _make_ctx(msg)
+        await obj.execute(ctx)
+        self.assertIsNotNone(ctx.message.correlation_id)
+
+    async def test_correlation_isolated_per_message(self):
+        """#81 concurrent messages do not clobber each other's id."""
+        seen: dict[str, str | None] = {}
+
+        class C(consumer.FunctionalConsumer):
+            async def process(self, ctx):
+                await asyncio.sleep(0.01)
+                seen[ctx.message.correlation_id] = log.correlation_id.get()
+
+        obj = C(config_module.Settings({}), None)
+        ctx1 = _make_ctx(_make_message(correlation_id='a'))
+        ctx2 = _make_ctx(_make_message(correlation_id='b'))
+        await asyncio.gather(obj.execute(ctx1), obj.execute(ctx2))
+        self.assertEqual(seen['a'], 'a')
+        self.assertEqual(seen['b'], 'b')
+
+    async def test_initialize_called_once_concurrently(self):
+        """#81 initialize() runs exactly once under concurrency."""
+        calls: list[int] = []
+
+        class C(consumer.FunctionalConsumer):
+            async def initialize(self):
+                calls.append(1)
+                await asyncio.sleep(0.01)
+
+            async def process(self, ctx):
+                pass
+
+        obj = C(config_module.Settings({}), None)
+        await asyncio.gather(
+            obj.execute(_make_ctx()), obj.execute(_make_ctx())
+        )
+        self.assertEqual(len(calls), 1)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,5 +1,6 @@
 """Tests for rejected.process"""
 
+import asyncio
 import copy
 import datetime
 import signal
@@ -7,7 +8,7 @@ import typing
 import unittest
 from unittest import mock
 
-from rejected import __version__, consumer, models, process
+from rejected import __version__, codecs, consumer, models, process
 from rejected import config as config_module
 from rejected import connection as connection_mod
 
@@ -105,8 +106,11 @@ def _make_ctx(
     channel: typing.Any = None,
     message: models.Message | None = None,
 ) -> models.ProcessingContext:
+    if conn is None:
+        conn = mock.Mock(spec=connection_mod.Connection)
+        conn.name = 'MockConnection'
     return models.ProcessingContext(
-        connection=conn or mock.Mock(spec=connection_mod.Connection),
+        connection=conn,
         channel=channel or mocks.CHANNEL,
         message=message or _make_message(),
     )
@@ -192,7 +196,7 @@ class TestProcess(unittest.IsolatedAsyncioTestCase, test_state.TestState):
     def test_setup_signal_handlers(self) -> None:
         signals = [
             mock.call(signal.SIGPROF, self._obj.on_sigprof),
-            mock.call(signal.SIGABRT, self._obj.stop),
+            mock.call(signal.SIGABRT, self._obj.on_sigabrt),
         ]
         with mock.patch('signal.signal') as signal_signal:
             self._obj.setup_sighandlers()
@@ -291,6 +295,7 @@ class TestProcess(unittest.IsolatedAsyncioTestCase, test_state.TestState):
 
         mock_conn = mock.Mock(spec=connection_mod.Connection)
         mock_conn.is_running = True
+        mock_conn.name = 'MockConnection'
         p.connections[mock_conn] = mock_conn
 
         ctx = _make_ctx(conn=mock_conn)
@@ -306,6 +311,7 @@ class TestProcess(unittest.IsolatedAsyncioTestCase, test_state.TestState):
 
         mock_conn = mock.Mock(spec=connection_mod.Connection)
         mock_conn.is_running = True
+        mock_conn.name = 'MockConnection'
         p.connections[mock_conn] = mock_conn
 
         ctx = _make_ctx(conn=mock_conn)
@@ -372,3 +378,168 @@ class TestProcess(unittest.IsolatedAsyncioTestCase, test_state.TestState):
 
         mocks.CHANNEL.basic_nack.assert_not_called()
         mock_conn.shutdown.assert_called_once()
+
+    async def test_decode_error_pops_in_flight(self) -> None:
+        """#70 a decode failure must not leak the in-flight entry."""
+        p = self.mock_setup()
+        p.state = p.STATE_IDLE
+        p.codec = mock.Mock()
+        p.codec.decode = mock.AsyncMock(side_effect=codecs.DecodeError('boom'))
+        mock_conn = mock.Mock(spec=connection_mod.Connection)
+        mock_conn.is_running = True
+        mock_conn.name = 'MockConnection'
+        p.connections[mock_conn] = mock_conn
+        ctx = _make_ctx(conn=mock_conn)
+        mocks.CHANNEL.basic_nack = mock.Mock()
+
+        await p.invoke_consumer(ctx)
+
+        self.assertEqual(len(p._in_flight), 0)
+
+    async def test_in_flight_keyed_by_connection(self) -> None:
+        """#73 same delivery tag on two connections does not collide."""
+        p = self.mock_setup()
+        p.state = p.STATE_IDLE
+        release = asyncio.Event()
+
+        async def execute(ctx: models.ProcessingContext) -> None:
+            await release.wait()
+            ctx.result = models.Result.MESSAGE_ACK
+
+        p.consumer.execute = execute
+        p.codec = None
+
+        conn_a = mock.Mock(spec=connection_mod.Connection)
+        conn_a.name, conn_a.is_running = 'a', True
+        conn_b = mock.Mock(spec=connection_mod.Connection)
+        conn_b.name, conn_b.is_running = 'b', True
+        ctx_a = _make_ctx(conn=conn_a, message=_make_message(delivery_tag=1))
+        ctx_b = _make_ctx(conn=conn_b, message=_make_message(delivery_tag=1))
+        mocks.CHANNEL.basic_ack = mock.Mock()
+
+        t1 = asyncio.ensure_future(p.invoke_consumer(ctx_a))
+        t2 = asyncio.ensure_future(p.invoke_consumer(ctx_b))
+        await asyncio.sleep(0)
+        self.assertEqual(len(p._in_flight), 2)
+        release.set()
+        await asyncio.gather(t1, t2)
+        self.assertEqual(len(p._in_flight), 0)
+
+    def test_stop_while_processing_defers_shutdown(self) -> None:
+        """#71 stop() while processing sets STOP_REQUESTED and waits."""
+        p = self.mock_setup()
+        p.state = p.STATE_PROCESSING
+        with mock.patch.object(p, 'shutdown_connections') as sc:
+            p.stop()
+            sc.assert_not_called()
+        self.assertEqual(p.state, p.STATE_STOP_REQUESTED)
+
+    def test_complete_pending_tasks_runs_them(self) -> None:
+        """#72 shutdown-scheduled tasks are run to completion."""
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+        ran: list[bool] = []
+
+        async def work() -> None:
+            ran.append(True)
+
+        self._obj.ioloop = loop
+        task = loop.create_task(work())
+        self._obj._complete_pending_tasks()
+        self.assertTrue(task.done())
+        self.assertEqual(ran, [True])
+
+    def test_on_connection_failure_while_processing_reconnects(self) -> None:
+        """#75 a terminal failure while processing triggers a reconnect."""
+        p = self.mock_setup()
+        conn = mock.Mock(spec=connection_mod.Connection)
+        conn.name = 'c'
+        p.connections['c'] = conn
+        p.state = p.STATE_PROCESSING
+        p.on_connection_failure('c')
+        conn.connect.assert_called_once()
+
+    def test_on_connection_ready_reconnect_consumes(self) -> None:
+        """#84 a reconnecting connection re-issues its own consume."""
+        p = self.mock_setup()
+        p.consumer = mock.Mock()
+        conn = mock.Mock(spec=connection_mod.Connection)
+        conn.name = 'c'
+        conn.should_consume = True
+        conn.channel = mock.Mock()
+        p.connections['c'] = conn
+        p.state = p.STATE_PROCESSING
+        p.on_connection_ready('c')
+        conn.consume.assert_called_once()
+
+    def test_reject_no_ack_does_not_raise(self) -> None:
+        """#85 reject() is a metrics-only no-op when ack is disabled."""
+        raw = copy.deepcopy(_CONFIG_RAW)
+        raw['Consumers']['MockConsumer']['ack'] = False
+        args = {**self.mock_args, 'config': _make_config(raw)}
+        p = self.mock_setup(self.new_process(args))
+        mock_conn = mock.Mock(spec=connection_mod.Connection)
+        mock_conn.is_running = True
+        ctx = _make_ctx(conn=mock_conn)
+        mocks.CHANNEL.basic_nack = mock.Mock()
+
+        p.reject(ctx, requeue=True)
+
+        mocks.CHANNEL.basic_nack.assert_not_called()
+        self.assertTrue(ctx.measurement.tags.get(p.NACKED))
+
+    def test_ack_returned_message_skips_broker(self) -> None:
+        """#86 returned messages have no delivery tag to ack."""
+        p = self.mock_setup()
+        mock_conn = mock.Mock(spec=connection_mod.Connection)
+        mock_conn.is_running = True
+        ctx = _make_ctx(
+            conn=mock_conn,
+            message=_make_message(delivery_tag=None, returned=True),
+        )
+        mocks.CHANNEL.basic_ack = mock.Mock()
+
+        p.ack_message(ctx)
+
+        mocks.CHANNEL.basic_ack.assert_not_called()
+
+    def test_reject_returned_message_skips_broker(self) -> None:
+        """#86 returned messages are not nacked on the broker."""
+        p = self.mock_setup()
+        mock_conn = mock.Mock(spec=connection_mod.Connection)
+        mock_conn.is_running = True
+        ctx = _make_ctx(
+            conn=mock_conn,
+            message=_make_message(delivery_tag=None, returned=True),
+        )
+        mocks.CHANNEL.basic_nack = mock.Mock()
+
+        p.reject(ctx, requeue=True)
+
+        mocks.CHANNEL.basic_nack.assert_not_called()
+
+    def test_shutdown_connections_shuts_down_connecting(self) -> None:
+        """#87 connections still connecting are also shut down."""
+        p = self.mock_setup()
+        conn = mock.Mock(spec=connection_mod.Connection)
+        conn.is_running = False
+        conn.is_connecting = True
+        p.connections['c'] = conn
+        p.shutdown_connections()
+        conn.shutdown.assert_called_once()
+
+    def test_on_sigabrt_schedules_stop(self) -> None:
+        """#88 SIGABRT schedules stop() on the loop, no direct I/O."""
+        p = self.mock_setup()
+        p.ioloop = mock.Mock()
+        p.on_sigabrt(signal.SIGABRT, None)
+        p.ioloop.call_soon_threadsafe.assert_called_once_with(
+            p.stop, signal.SIGABRT
+        )
+
+    def test_on_sigprof_schedules_report(self) -> None:
+        """#88 SIGPROF schedules the stats report on the loop."""
+        p = self.mock_setup()
+        p.ioloop = mock.Mock()
+        p.on_sigprof(signal.SIGPROF, None)
+        p.ioloop.call_soon_threadsafe.assert_called_once_with(p._report_stats)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -434,6 +434,23 @@ class TestProcess(unittest.IsolatedAsyncioTestCase, test_state.TestState):
             sc.assert_not_called()
         self.assertEqual(p.state, p.STATE_STOP_REQUESTED)
 
+    def test_deferred_shutdown_fires_when_in_flight_drains(self) -> None:
+        """#71 deferred shutdown runs once the last in-flight drains."""
+        p = self.mock_setup()
+        p.state = p.STATE_PROCESSING
+        p.stop()
+        self.assertEqual(p.state, p.STATE_STOP_REQUESTED)
+
+        # invoke_consumer pops the tag from _in_flight before calling
+        # on_processed, so the last message finishing leaves it empty.
+        ctx = _make_ctx(message=_make_message())
+        ctx.result = models.Result.MESSAGE_ACK
+        self.assertEqual(len(p._in_flight), 0)
+        with mock.patch.object(p, 'shutdown_connections') as sc:
+            with mock.patch.object(p, 'ack_message'):
+                p.on_processed(ctx)
+        sc.assert_called_once()
+
     def test_complete_pending_tasks_runs_them(self) -> None:
         """#72 shutdown-scheduled tasks are run to completion."""
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary

Fixes 17 verified bugs in the message-processing lifecycle across `process.py`, `consumer.py`, `connection.py`, and `log.py`. These cover the ack/nack path, in-flight tracking, connection reconnect/shutdown, signal handling, and consumer lifecycle hooks.

## Problem / Solution

Each fix is surgical and covered by a reproducing test.

- **#68** `Consumer.finish()` was documented in the lifecycle but never called → added `await self.finish()` in `_process_standard`.
- **#69** `_republish` dropped all AMQP properties except headers, breaking error/drop-exchange retry pipelines → now copies content type/encoding, type, correlation_id, priority, expiration.
- **#70** `DecodeError` leaked the message in `_in_flight`, wedging state/shutdown → pop the tag in the error branch.
- **#71** Graceful-shutdown wait in `Process.stop()` was dead code → set `STATE_STOP_REQUESTED` before `shutdown_connections`.
- **#72** Event loop stopped before `consumer.shutdown()`/`codec.close()` ran → pending tasks now run to completion after `run_forever`.
- **#73** `_in_flight` keyed by delivery tag alone collided across connections → now keyed by `(connection.name, delivery_tag)`.
- **#74** `Connection.shutdown()` crashed on an already-closed connection → no-op when closed, guarded `close()`, stopped deleting `self.connection`.
- **#75** Terminal channel error while processing left a zombie → `Process.on_connection_failure` reconnects when processing.
- **#78** Non-default SSL protocol path never enabled hostname verification → `check_hostname = True` set before `verify_mode`.
- **#80** Non-numeric `X-Processing-Exceptions` header caused an infinite requeue loop → conversions wrapped, default to 0.
- **#81** Per-message correlation ID clobbered across concurrent messages → carried on the message + a per-task `contextvar`; `_pre_execute` runs inside the lock; `initialize()` guarded.
- **#82** `KeyboardInterrupt` handler double-nacked the same delivery tag → removed the redundant `reject()`.
- **#84** `basic_consume` never re-issued after reconnect in multi-connection consumers → re-issues for the specific connection.
- **#85** `ack: false` consumers raised `RuntimeError` on any non-ACK result → rejection branches skip the broker nack when `no_ack`.
- **#86** Returned messages (`Basic.Return`, `delivery_tag=None`) hit the ack/nack path → short-circuited.
- **#87** `shutdown_connections` skipped `STATE_CONNECTING` connections, hanging shutdown → now shuts them down too.
- **#88** SIGABRT/SIGPROF handlers performed pika I/O directly in the signal handler → now only `call_soon_threadsafe` onto the loop.

## Testing

Full suite green (231 tests) + ruff clean. New/updated tests in `tests/test_process.py`, `tests/test_consumer.py`, and new `tests/test_connection.py`.

Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73
Closes #74
Closes #75
Closes #78
Closes #80
Closes #81
Closes #82
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-message correlation ID tracking for better logging during concurrent processing.
  * Republished processing failures now preserve original AMQP message properties and improve retry/error handling.
  * Improved connection lifecycle behavior for smoother reconnects and shutdowns, including safer signal handling.
* **Bug Fixes**
  * Fixed duplicate initialization under concurrency and hardened handling of invalid processing-exception headers.
  * Corrected in-flight tracking to avoid delivery-tag collisions and improved ack/reject behavior for returned messages.
  * Enabled SSL hostname verification for safer TLS connections.
* **Tests**
  * Expanded unit and async test coverage for the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->