### PR TITLE
Fix daemon-lifecycle signal handling and unbounded stats growth

### DIFF
--- a/rejected/controller.py
+++ b/rejected/controller.py
@@ -72,17 +72,25 @@ class Controller:
                 quantity=self.args.quantity,
                 max_messages=self.args.max_messages,
             )
+            # A shutdown signal may have arrived while constructing the MCP
+            if self._shutdown_requested:
+                break
             try:
                 self._mcp.run()
             except KeyboardInterrupt:
                 LOGGER.info('Caught CTRL-C, shutting down')
-                break
+                self._shutdown_requested = True
             except Exception:
                 exc_info = sys.exc_info()
                 if self._sentry_client:
                     LOGGER.debug('Sending exception to sentry')
                     sentry_sdk.capture_exception(exc_info)
                 raise
+            finally:
+                # Always stop children on the main thread once the run loop
+                # has exited so non-daemon processes cannot leak or wedge the
+                # parent at atexit.
+                self._mcp.stop_processes()
 
             if not self._reload_requested:
                 break
@@ -106,16 +114,24 @@ class Controller:
     def _on_sighup(self, _signum: int, _frame: types.FrameType | None) -> None:
         LOGGER.info('Received SIGHUP — reloading configuration')
         self._reload_requested = True
-        if self._mcp:
-            self._mcp.stop_processes()
+        self._request_stop()
 
     def _on_sigterm(
         self, _signum: int, _frame: types.FrameType | None
     ) -> None:
         LOGGER.info('Received SIGTERM, initiating shutdown')
         self._shutdown_requested = True
+        self._request_stop()
+
+    def _request_stop(self) -> None:
+        """Signal the run loop to exit without stopping children from within
+        the signal handler. Cancel the poll itimer and flag the MCP; the main
+        flow performs the actual ``stop_processes()`` once the loop unwinds,
+        so a poll cannot interleave and respawn orphaned children.
+        """
+        signal.setitimer(signal.ITIMER_REAL, 0, 0)
         if self._mcp:
-            self._mcp.stop_processes()
+            self._mcp.stop_requested = True
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/rejected/mcp.py
+++ b/rejected/mcp.py
@@ -81,6 +81,7 @@ class MasterControlProgram(state.State):
         )
         self.consumers: dict[str, Consumer] = {}
         self.config: models.Config = config
+        self.consumer_baselines: dict[str, collections.Counter[str]] = {}
         self.last_poll_results: dict[str, typing.Any] = {}
         self.poll_data: dict[str, typing.Any] = {'time': 0, 'processes': []}
         self.poll_timer: float | None = None
@@ -95,6 +96,9 @@ class MasterControlProgram(state.State):
 
         # Flag to indicate child creation error
         self.child_abort: bool = False
+
+        # Flag set by the controller to request the run loop to exit
+        self.stop_requested: bool = False
 
         # Carry for logging internal stats collection data
         self.log_stats_enabled: bool = config.stats.log
@@ -171,27 +175,40 @@ class MasterControlProgram(state.State):
         :type data: dict
 
         """
-        timestamp = data['timestamp']
-        del data['timestamp']
+        # Read the timestamp without mutating the caller's data
+        timestamp = data.get('timestamp')
 
         # Iterate through the last poll results
         stats = self.consumer_stats_counter()
         consumer_stats: dict[str, dict[str, typing.Any]] = {}
         for name in data.keys():
+            if name == 'timestamp':
+                continue
             consumer_stats[name] = self.consumer_stats_counter()
             consumer_stats[name]['processes'] = self.process_count(name)
+            # Fold in counts retired from pruned dead processes so the
+            # per-consumer totals stay monotonic for Prometheus deltas
+            baseline = self.consumer_baselines.get(name, {})
             for proc in data[name].keys():
                 for key in stats:
                     value = data[name][proc]['counts'].get(key, 0)
                     stats[key] += value
                     consumer_stats[name][key] += value
+            for key in stats:
+                value = baseline.get(key, 0)
+                stats[key] += value
+                consumer_stats[name][key] += value
 
         # Return a data structure that can be used in reporting out the stats
         stats['processes'] = len(self.active_processes())
         return {
             'last_poll': timestamp,
             'consumers': consumer_stats,
-            'process_data': data,
+            'process_data': {
+                name: procs
+                for name, procs in data.items()
+                if name != 'timestamp'
+            },
             'counts': stats,
         }
 
@@ -200,6 +217,9 @@ class MasterControlProgram(state.State):
         processes needed.
 
         """
+        if not self.is_running:
+            LOGGER.debug('Not checking process counts, not running')
+            return
         if self.max_messages:
             LOGGER.debug(
                 'Skipping process respawn (max_messages=%i)', self.max_messages
@@ -460,10 +480,20 @@ class MasterControlProgram(state.State):
 
         """
         LOGGER.info('SIGCHLD received from child')
-        if not self.active_processes(False):
-            LOGGER.info('Stopping with no active processes and child error')
+
+        # active_processes prunes any children that have exited
+        if self.active_processes(False):
+            return
+
+        # Only tear the daemon down when we are not meant to keep running:
+        # a child failed to spawn, max_messages mode has drained, or we are
+        # already shutting down. Otherwise let the next poll respawn.
+        if self.child_abort or self.max_messages or self.is_shutting_down:
+            LOGGER.info('Stopping with no active processes')
             signal.setitimer(signal.ITIMER_REAL, 0, 0)
             self.set_state(self.STATE_STOPPED)
+        else:
+            LOGGER.info('All children exited; next poll will respawn')
 
     def on_timer(
         self, _signum: int, _unused_frame: types.FrameType | None
@@ -597,6 +627,23 @@ class MasterControlProgram(state.State):
         """
         return self.consumers[name].qty - self.process_count(name)
 
+    def retire_poll_results(self, consumer: str, name: str) -> None:
+        """Fold a dead process's final counts into the consumer baseline and
+        drop its per-process poll entry so ``last_poll_results`` stays bounded
+        while the per-consumer totals remain monotonic for Prometheus deltas.
+
+        :param str consumer: The consumer name
+        :param str name: The process name
+
+        """
+        proc_results = self.last_poll_results.get(consumer, {}).pop(name, None)
+        if not proc_results:
+            return
+        baseline = self.consumer_baselines.setdefault(
+            consumer, collections.Counter()
+        )
+        baseline.update(proc_results.get('counts', {}))
+
     def remove_consumer_process(self, consumer: str, name: str) -> None:
         """Remove all details for the specified consumer and process name.
 
@@ -605,6 +652,7 @@ class MasterControlProgram(state.State):
 
         """
         my_pid = os.getpid()
+        self.retire_poll_results(consumer, name)
         if name in self.consumers[consumer].processes.keys():
             try:
                 child = self.consumers[consumer].processes[name]
@@ -651,11 +699,13 @@ class MasterControlProgram(state.State):
         # Kick off the poll timer
         signal.setitimer(signal.ITIMER_REAL, self.poll_interval, 0)
 
-        # Loop for the lifetime of the app, pausing for a signal to pop up
-        while self.is_running:
+        # Loop for the lifetime of the app. Use a bounded sleep rather than
+        # signal.pause() so a stop request or signal delivered between the
+        # loop check and the wait cannot wedge us forever (lost wakeup).
+        while self.is_running and not self.stop_requested:
             if not self.is_sleeping:
                 self.set_state(self.STATE_SLEEPING)
-            signal.pause()
+            time.sleep(1)
 
         # Note we're exiting run
         LOGGER.info('Exiting Master Control Program')
@@ -717,6 +767,7 @@ class MasterControlProgram(state.State):
             LOGGER.critical(
                 'Failed to start %s for %s: %r', process_name, name, error
             )
+            self.child_abort = True
             try:
                 del self.consumers[name].processes[process_name]
             except AttributeError as error:
@@ -730,6 +781,9 @@ class MasterControlProgram(state.State):
         :param int quantity: The quantity of processes to start
 
         """
+        if not self.is_running:
+            LOGGER.debug('Not starting processes, not running')
+            return
         for _i in range(0, quantity or 0):
             self.start_process(name)
 

--- a/rejected/state.py
+++ b/rejected/state.py
@@ -47,6 +47,10 @@ class State:
         if new_state not in self.STATES:
             raise ValueError(f'Invalid state value: {new_state!r}')
 
+        # A stopped object must not be resurrected into an active state
+        if self.state == self.STATE_STOPPED and new_state == self.STATE_ACTIVE:
+            raise ValueError('Cannot transition from Stopped to Active')
+
         LOGGER.debug(
             'State changing from %s to %s',
             self.STATES[self.state],

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -54,9 +54,13 @@ class ControllerSignalTests(unittest.TestCase):
         self.ctrl._on_sigterm(signal.SIGTERM, None)
         self.assertTrue(self.ctrl._shutdown_requested)
 
-    def test_on_sigterm_calls_stop_processes(self):
+    def test_on_sigterm_requests_mcp_stop(self):
         self.ctrl._on_sigterm(signal.SIGTERM, None)
-        self.ctrl._mcp.stop_processes.assert_called_once()
+        self.assertTrue(self.ctrl._mcp.stop_requested)
+
+    def test_on_sigterm_does_not_stop_processes_in_handler(self):
+        self.ctrl._on_sigterm(signal.SIGTERM, None)
+        self.ctrl._mcp.stop_processes.assert_not_called()
 
     def test_on_sigterm_no_mcp(self):
         self.ctrl._mcp = None
@@ -67,9 +71,13 @@ class ControllerSignalTests(unittest.TestCase):
         self.ctrl._on_sighup(signal.SIGHUP, None)
         self.assertTrue(self.ctrl._reload_requested)
 
-    def test_on_sighup_calls_stop_processes(self):
+    def test_on_sighup_requests_mcp_stop(self):
         self.ctrl._on_sighup(signal.SIGHUP, None)
-        self.ctrl._mcp.stop_processes.assert_called_once()
+        self.assertTrue(self.ctrl._mcp.stop_requested)
+
+    def test_on_sighup_does_not_stop_processes_in_handler(self):
+        self.ctrl._on_sighup(signal.SIGHUP, None)
+        self.ctrl._mcp.stop_processes.assert_not_called()
 
     def test_on_sighup_no_mcp(self):
         self.ctrl._mcp = None
@@ -141,6 +149,56 @@ class ControllerRunTests(unittest.TestCase):
             with mock.patch.object(self.ctrl, '_setup_signals'):
                 self.ctrl.run()
         mock_cls.assert_not_called()
+
+    def test_normal_run_stops_processes(self):
+        mock_mcp = mock.Mock()
+        with mock.patch(
+            'rejected.controller.mcp.MasterControlProgram',
+            return_value=mock_mcp,
+        ):
+            with mock.patch.object(self.ctrl, '_setup_signals'):
+                self.ctrl.run()
+        mock_mcp.stop_processes.assert_called_once()
+
+    def test_keyboard_interrupt_stops_processes(self):
+        mock_mcp = mock.Mock()
+        mock_mcp.run.side_effect = KeyboardInterrupt
+        with mock.patch(
+            'rejected.controller.mcp.MasterControlProgram',
+            return_value=mock_mcp,
+        ):
+            with mock.patch.object(self.ctrl, '_setup_signals'):
+                self.ctrl.run()
+        mock_mcp.stop_processes.assert_called_once()
+
+    def test_exception_stops_processes_before_reraise(self):
+        mock_mcp = mock.Mock()
+        mock_mcp.run.side_effect = RuntimeError('boom')
+        with mock.patch(
+            'rejected.controller.mcp.MasterControlProgram',
+            return_value=mock_mcp,
+        ):
+            with mock.patch.object(self.ctrl, '_setup_signals'):
+                with self.assertRaises(RuntimeError):
+                    self.ctrl.run()
+        mock_mcp.stop_processes.assert_called_once()
+
+    def test_shutdown_during_construction_skips_run(self):
+        mock_mcp = mock.Mock()
+
+        def construct(*_args, **_kwargs):
+            # Simulate a SIGTERM arriving while the MCP is being built
+            self.ctrl._shutdown_requested = True
+            return mock_mcp
+
+        with mock.patch(
+            'rejected.controller.mcp.MasterControlProgram',
+            side_effect=construct,
+        ):
+            with mock.patch.object(self.ctrl, '_setup_signals'):
+                self.ctrl.run()
+        mock_mcp.run.assert_not_called()
+        mock_mcp.stop_processes.assert_not_called()
 
 
 class ControllerReloadTests(unittest.TestCase):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,7 +1,9 @@
 """Tests for the MCP"""
 
+import collections
 import multiprocessing
 import typing
+import unittest
 from unittest import mock
 
 from rejected import config as config_module
@@ -26,3 +28,168 @@ class TestMCP(test_state.TestState):
 
     def test_mcp_init_queue_initialized(self):
         self.assertIsInstance(self._obj.stats_queue, mock.MagicMock)
+
+
+class MCPTestCase(unittest.TestCase):
+    """Base for MCP behavior tests that need a constructed MCP instance."""
+
+    CONFIG: typing.ClassVar[dict] = {'poll_interval': 30.0, 'Consumers': {}}
+
+    @mock.patch.object(multiprocessing, 'Queue')
+    def setUp(self, _mock_queue_unused):
+        self.cfg = config_module.Config.model_validate(self.CONFIG)
+        self._obj = mcp.MasterControlProgram(self.cfg)
+
+
+class OnSigchldTests(MCPTestCase):
+    """#76 — on_sigchld should only stop the daemon on abort/max_messages/
+    shutdown, otherwise prune and let the next poll respawn."""
+
+    def _no_active(self):
+        return mock.patch.object(
+            self._obj, 'active_processes', return_value=[]
+        )
+
+    @mock.patch('rejected.mcp.signal.setitimer')
+    def test_respawn_path_does_not_stop(self, mock_setitimer):
+        self._obj.state = self._obj.STATE_ACTIVE
+        with self._no_active():
+            self._obj.on_sigchld(0, None)
+        self.assertEqual(self._obj.state, self._obj.STATE_ACTIVE)
+        mock_setitimer.assert_not_called()
+
+    @mock.patch('rejected.mcp.signal.setitimer')
+    def test_child_abort_stops(self, mock_setitimer):
+        self._obj.state = self._obj.STATE_ACTIVE
+        self._obj.child_abort = True
+        with self._no_active():
+            self._obj.on_sigchld(0, None)
+        self.assertEqual(self._obj.state, self._obj.STATE_STOPPED)
+        mock_setitimer.assert_called_once()
+
+    @mock.patch('rejected.mcp.signal.setitimer')
+    def test_max_messages_stops(self, mock_setitimer):
+        self._obj.state = self._obj.STATE_ACTIVE
+        self._obj.max_messages = 10
+        with self._no_active():
+            self._obj.on_sigchld(0, None)
+        self.assertEqual(self._obj.state, self._obj.STATE_STOPPED)
+        mock_setitimer.assert_called_once()
+
+    @mock.patch('rejected.mcp.signal.setitimer')
+    def test_active_processes_no_stop(self, mock_setitimer):
+        self._obj.state = self._obj.STATE_ACTIVE
+        with mock.patch.object(
+            self._obj, 'active_processes', return_value=[mock.Mock()]
+        ):
+            self._obj.on_sigchld(0, None)
+        self.assertEqual(self._obj.state, self._obj.STATE_ACTIVE)
+        mock_setitimer.assert_not_called()
+
+
+class StartProcessAbortTests(MCPTestCase):
+    """#76 — a failed spawn sets child_abort."""
+
+    def test_start_process_sets_child_abort_on_oserror(self):
+        self._obj.consumers['foo'] = mcp.Consumer(0, {}, 1, 'foo')
+        with mock.patch.object(self._obj, 'new_process') as new_process:
+            proc = mock.Mock()
+            proc.start.side_effect = OSError('nope')
+            new_process.return_value = ('foo-1', proc)
+            self._obj.start_process('foo')
+        self.assertTrue(self._obj.child_abort)
+
+
+class ProcessCountGuardTests(MCPTestCase):
+    """#91 — respawn paths must bail when not running."""
+
+    def setUp(self):
+        super().setUp()
+        self._obj.consumers['foo'] = mcp.Consumer(0, {}, 1, 'foo')
+
+    def test_check_process_counts_bails_when_not_running(self):
+        self._obj.state = self._obj.STATE_SHUTTING_DOWN
+        with mock.patch.object(self._obj, 'start_processes') as start:
+            self._obj.check_process_counts()
+        start.assert_not_called()
+
+    def test_check_process_counts_runs_when_active(self):
+        self._obj.state = self._obj.STATE_ACTIVE
+        with mock.patch.object(self._obj, 'start_processes') as start:
+            self._obj.check_process_counts()
+        start.assert_called_once_with('foo', 1)
+
+    def test_start_processes_bails_when_not_running(self):
+        self._obj.state = self._obj.STATE_SHUTTING_DOWN
+        with mock.patch.object(self._obj, 'start_process') as start_one:
+            self._obj.start_processes('foo', 2)
+        start_one.assert_not_called()
+
+
+class CalculateStatsTests(MCPTestCase):
+    """#92 — no input mutation, no aliasing, dead-process baselines."""
+
+    def setUp(self):
+        super().setUp()
+        self._obj.consumers['foo'] = mcp.Consumer(0, {}, 1, 'foo')
+
+    @staticmethod
+    def _data():
+        return {
+            'timestamp': 123.0,
+            'foo': {'foo-1': {'counts': {'processed': 5, 'acked': 5}}},
+        }
+
+    def test_does_not_mutate_input_timestamp(self):
+        data = self._data()
+        self._obj.calculate_stats(data)
+        self.assertIn('timestamp', data)
+
+    def test_process_data_not_aliased(self):
+        data = self._data()
+        stats = self._obj.calculate_stats(data)
+        self.assertIsNot(stats['process_data'], data)
+        self.assertNotIn('timestamp', stats['process_data'])
+
+    def test_sums_live_process_counts(self):
+        stats = self._obj.calculate_stats(self._data())
+        self.assertEqual(stats['consumers']['foo']['processed'], 5)
+
+    def test_folds_in_baseline(self):
+        self._obj.consumer_baselines['foo'] = collections.Counter(
+            {'processed': 10}
+        )
+        data = {
+            'timestamp': 1.0,
+            'foo': {'foo-2': {'counts': {'processed': 3}}},
+        }
+        stats = self._obj.calculate_stats(data)
+        self.assertEqual(stats['consumers']['foo']['processed'], 13)
+
+
+class RetirePollResultsTests(MCPTestCase):
+    """#92 — retiring a process prunes its entry and folds its counts."""
+
+    def test_folds_counts_and_prunes(self):
+        self._obj.last_poll_results = {
+            'foo': {'foo-1': {'counts': {'processed': 7}}}
+        }
+        self._obj.retire_poll_results('foo', 'foo-1')
+        self.assertNotIn('foo-1', self._obj.last_poll_results['foo'])
+        self.assertEqual(self._obj.consumer_baselines['foo']['processed'], 7)
+
+    def test_accumulates_across_retirements(self):
+        self._obj.last_poll_results = {
+            'foo': {
+                'foo-1': {'counts': {'processed': 7}},
+                'foo-2': {'counts': {'processed': 4}},
+            }
+        }
+        self._obj.retire_poll_results('foo', 'foo-1')
+        self._obj.retire_poll_results('foo', 'foo-2')
+        self.assertEqual(self._obj.consumer_baselines['foo']['processed'], 11)
+
+    def test_missing_entry_is_noop(self):
+        self._obj.last_poll_results = {'foo': {}}
+        self._obj.retire_poll_results('foo', 'foo-1')
+        self.assertNotIn('foo', self._obj.consumer_baselines)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,6 +22,18 @@ class TestState(unittest.TestCase):
         self._obj.set_state(self._obj.STATE_CONNECTING)
         self.assertEqual(self._obj.state, self._obj.STATE_CONNECTING)
 
+    def test_set_state_stopped_to_active_rejected(self):
+        self._obj.state = self._obj.STATE_STOPPED
+        self.assertRaises(
+            ValueError, self._obj.set_state, self._obj.STATE_ACTIVE
+        )
+        self.assertEqual(self._obj.state, self._obj.STATE_STOPPED)
+
+    def test_set_state_stopped_to_shutting_down_allowed(self):
+        self._obj.state = self._obj.STATE_STOPPED
+        self._obj.set_state(self._obj.STATE_SHUTTING_DOWN)
+        self.assertEqual(self._obj.state, self._obj.STATE_SHUTTING_DOWN)
+
     def test_set_state_state_start(self):
         self.state = self._obj.STATE_IDLE
         value = 86400


### PR DESCRIPTION
## Summary

Fixes 6 verified daemon-lifecycle bugs in `mcp.py`, `controller.py`, and `state.py`, centered on a coherent signal/shutdown flow and bounded stats growth.

## Problem / Solution

- **#76** `on_sigchld` shut the daemon down when the last child died instead of respawning → only stops on `child_abort`/`max_messages`/`is_shutting_down`; otherwise prunes and lets the next poll respawn. Wired up the previously-dead `child_abort` flag.
- **#89** Lost-wakeup race between the `is_running` check and `signal.pause()` → replaced with a bounded wait loop that re-checks `is_running`/`stop_requested`.
- **#90** `KeyboardInterrupt`/exception exit paths never stopped children (parent hung at atexit join) → `controller.run()` stops processes in a `finally`.
- **#91** `stop_processes()` in a signal handler could interleave with `poll()` and respawn orphaned children → handlers now only set a flag + cancel the itimer; `check_process_counts`/`start_processes` bail when not running; shutdown happens on the main thread.
- **#92** `last_poll_results` grew without bound and inflated logged stats → dead-process entries are pruned with their final counts folded into a retained per-consumer baseline (keeps Prometheus deltas correct); also fixed input mutation and the `process_data` aliasing.
- **#99** SIGTERM between MCP construction and `run()` was nullified and `set_state` allowed STOPPED→ACTIVE → checks `_shutdown_requested` before `run()`; `set_state` rejects the STOPPED→ACTIVE transition.

### Note on `state.py`
`set_state` now raises `ValueError` on exactly one transition (`STATE_STOPPED → STATE_ACTIVE`). Verified safe for `process.py`/`connection.py`, which never make that transition. No general transition table was added.

## Testing

Full suite green (235 tests) + ruff clean. Tests in `tests/test_mcp.py`, `tests/test_controller.py`, `tests/test_state.py`.

Closes #76
Closes #89
Closes #90
Closes #91
Closes #92
Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so background work stops more reliably, including during interrupts, errors, and partial startup.
  * Prevented certain child processes from being stopped from signal handlers, reducing the chance of unstable shutdown behavior.
  * Fixed a state transition issue so stopped items can’t be reactivated unexpectedly.
  * Made process monitoring and restart behavior more consistent when children exit, fail to start, or are already shutting down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->