### PR TITLE
Fix silent data-corruption and lock contention in Codec

### DIFF
--- a/rejected/codecs.py
+++ b/rejected/codecs.py
@@ -75,7 +75,7 @@ class Codec:
     ) -> None:
         self._schema_registry = schema_registry
         self._avro_schemas: dict[str, dict[str, typing.Any]] = {}
-        self._schema_lock = asyncio.Lock()
+        self._schema_locks: dict[str, asyncio.Lock] = {}
         self._http_client: typing.Any | None = None
 
     async def decode(
@@ -110,24 +110,11 @@ class Codec:
                 schema = await self._avro_schema(message_type)
                 return fastavro.schemaless_reader(io.BytesIO(body), schema)
 
-            if content_type == 'application/json':
-                return _load_json(body)
-            if umsgpack and content_type == 'application/msgpack':
-                return _load_msgpack(body)
-            if content_type == 'application/x-plist':
-                return plistlib.loads(body)
-            if content_type == 'text/csv':
-                return _load_csv(body)
-            if bs4 and content_type in BS4_MIME_TYPES:
-                return _load_bs4(body, content_type)
-            if content_type in YAML_MIME_TYPES:
-                return yaml.safe_load(body)
+            return _decode_body(body, content_type)
         except DecodeError:
             raise
         except Exception as error:
             raise DecodeError(str(error)) from error
-
-        return body
 
     async def encode(
         self,
@@ -210,11 +197,15 @@ class Codec:
 
     async def _avro_schema(self, message_type: str) -> dict[str, typing.Any]:
         """Return the parsed Avro schema, loading and caching on
-        first access. Lock prevents duplicate fetches under
-        concurrent message processing."""
+        first access. A per-message-type lock prevents duplicate
+        fetches for the same type without serializing loads of
+        different types."""
         if message_type in self._avro_schemas:
             return self._avro_schemas[message_type]
-        async with self._schema_lock:
+        lock = self._schema_locks.get(message_type)
+        if lock is None:
+            lock = self._schema_locks[message_type] = asyncio.Lock()
+        async with lock:
             if message_type not in self._avro_schemas:
                 self._avro_schemas[
                     message_type
@@ -277,6 +268,11 @@ class Codec:
                 if response.status_code == 200:
                     schema: dict[str, typing.Any] = response.json()
                     return schema
+                if 400 <= response.status_code < 500:
+                    raise DecodeError(
+                        f'Failed to fetch Avro schema for '
+                        f'{message_type}: HTTP {response.status_code}'
+                    )
                 last_err = DecodeError(
                     f'Failed to fetch Avro schema for '
                     f'{message_type}: HTTP {response.status_code}'
@@ -294,6 +290,38 @@ class Codec:
 # --- Internal helpers (stateless, sync) ---
 
 
+def _decode_body(body: bytes, content_type: str | None) -> typing.Any:
+    """Deserialize a (decompressed) body by content type.
+
+    Raises DecodeError when the content type requires an optional
+    dependency that is not installed. Returns the raw body when the
+    content type has no registered deserializer.
+
+    """
+    if content_type == 'application/json':
+        return _load_json(body)
+    if content_type == 'application/msgpack':
+        if umsgpack is None:
+            raise DecodeError(
+                'umsgpack is required for MessagePack decoding; '
+                'install rejected[msgpack]'
+            )
+        return _load_msgpack(body)
+    if content_type == 'application/x-plist':
+        return plistlib.loads(body)
+    if content_type == 'text/csv':
+        return _load_csv(body)
+    if content_type in BS4_MIME_TYPES:
+        if bs4 is None:
+            raise DecodeError(
+                'bs4 is required for HTML/XML decoding; install rejected[html]'
+            )
+        return _load_bs4(body, content_type)
+    if content_type in YAML_MIME_TYPES:
+        return yaml.safe_load(body)
+    return body
+
+
 def _compress(body: typing.Any, content_encoding: str) -> bytes:
     """Apply content-encoding compression to a body."""
     if isinstance(body, str):
@@ -302,7 +330,7 @@ def _compress(body: typing.Any, content_encoding: str) -> bytes:
         return gzip.compress(body)
     if content_encoding == 'bzip2':
         return bz2.compress(body)
-    return body
+    raise EncodeError(f'Unsupported content_encoding: {content_encoding!r}')
 
 
 def _load_json(value: bytes | str) -> typing.Any:

--- a/rejected/codecs.py
+++ b/rejected/codecs.py
@@ -205,12 +205,17 @@ class Codec:
         lock = self._schema_locks.get(message_type)
         if lock is None:
             lock = self._schema_locks[message_type] = asyncio.Lock()
-        async with lock:
-            if message_type not in self._avro_schemas:
-                self._avro_schemas[
-                    message_type
-                ] = await self._load_avro_schema(message_type)
-            return self._avro_schemas[message_type]
+        try:
+            async with lock:
+                if message_type not in self._avro_schemas:
+                    self._avro_schemas[
+                        message_type
+                    ] = await self._load_avro_schema(message_type)
+                return self._avro_schemas[message_type]
+        except Exception:
+            if self._schema_locks.get(message_type) is lock:
+                self._schema_locks.pop(message_type, None)
+            raise
 
     async def _load_avro_schema(
         self, message_type: str

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,0 +1,162 @@
+"""Tests for rejected.codecs"""
+
+import asyncio
+import gzip
+import unittest
+from unittest import mock
+
+from rejected import codecs, models
+
+
+class MissingOptionalDependencyDecodeTests(unittest.IsolatedAsyncioTestCase):
+    """Decode must raise DecodeError when the required optional
+    dependency for the content type is not installed, rather than
+    silently returning the raw bytes."""
+
+    async def test_msgpack_missing_raises_decode_error(self):
+        codec = codecs.Codec()
+        with mock.patch.object(codecs, 'umsgpack', None):
+            with self.assertRaises(codecs.DecodeError) as ctx:
+                await codec.decode(b'\x90', 'application/msgpack', None)
+        self.assertIn('umsgpack is required', str(ctx.exception))
+
+    async def test_bs4_missing_raises_decode_error(self):
+        codec = codecs.Codec()
+        with mock.patch.object(codecs, 'bs4', None):
+            with self.assertRaises(codecs.DecodeError) as ctx:
+                await codec.decode(b'<html></html>', 'text/html', None)
+        self.assertIn('bs4 is required', str(ctx.exception))
+
+    async def test_bs4_missing_raises_for_xml(self):
+        codec = codecs.Codec()
+        with mock.patch.object(codecs, 'bs4', None):
+            with self.assertRaises(codecs.DecodeError):
+                await codec.decode(b'<root/>', 'text/xml', None)
+
+
+class CompressionEncodeTests(unittest.IsolatedAsyncioTestCase):
+    """Encode must not silently emit an uncompressed body when the
+    content_encoding claims an unsupported compression scheme."""
+
+    async def test_unknown_content_encoding_raises(self):
+        codec = codecs.Codec()
+        with self.assertRaises(codecs.EncodeError) as ctx:
+            await codec.encode('hello', 'text/plain', 'deflate')
+        self.assertIn('Unsupported content_encoding', str(ctx.exception))
+
+    async def test_gzip_round_trip(self):
+        codec = codecs.Codec()
+        encoded = await codec.encode('hello', 'text/plain', 'gzip')
+        self.assertEqual(gzip.decompress(encoded), b'hello')
+        decoded = await codec.decode(encoded, 'text/plain', 'gzip')
+        self.assertEqual(decoded, b'hello')
+
+    async def test_bzip2_supported(self):
+        codec = codecs.Codec()
+        encoded = await codec.encode('hello', 'text/plain', 'bzip2')
+        self.assertNotEqual(encoded, b'hello')
+
+
+def _http_codec():
+    return codecs.Codec(
+        models.SchemaRegistryConfig(
+            type='http', uri='http://registry/{0}.avsc'
+        )
+    )
+
+
+def _fake_httpx():
+    """A stand-in httpx module whose RequestError is a real
+    exception class so ``except httpx.RequestError`` works."""
+    fake = mock.Mock()
+    fake.RequestError = type('RequestError', (Exception,), {})
+    return fake
+
+
+class AvroHttpSchemaTests(unittest.IsolatedAsyncioTestCase):
+    """HTTP schema loading must fail fast on client errors and must
+    not serialize loads of different message types."""
+
+    async def test_404_fails_fast_without_retry(self):
+        codec = _http_codec()
+        response = mock.Mock(status_code=404)
+        codec._http_client = mock.Mock()
+        codec._http_client.get = mock.AsyncMock(return_value=response)
+        with (
+            mock.patch.object(codecs, 'httpx', _fake_httpx()),
+            mock.patch.object(codecs.asyncio, 'sleep') as sleep,
+        ):
+            with self.assertRaises(codecs.DecodeError) as ctx:
+                await codec._avro_schema('missing_type')
+        self.assertIn('HTTP 404', str(ctx.exception))
+        self.assertEqual(codec._http_client.get.await_count, 1)
+        sleep.assert_not_awaited()
+
+    async def test_500_retries(self):
+        codec = _http_codec()
+        response = mock.Mock(status_code=503)
+        codec._http_client = mock.Mock()
+        codec._http_client.get = mock.AsyncMock(return_value=response)
+        with (
+            mock.patch.object(codecs, 'httpx', _fake_httpx()),
+            mock.patch.object(codecs.asyncio, 'sleep', mock.AsyncMock()),
+        ):
+            with self.assertRaises(codecs.DecodeError):
+                await codec._avro_schema('flaky_type')
+        self.assertEqual(codec._http_client.get.await_count, 3)
+
+    async def test_different_types_load_concurrently(self):
+        codec = _http_codec()
+        release = asyncio.Event()
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_get(uri):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await release.wait()
+            in_flight -= 1
+            resp = mock.Mock(status_code=200)
+            resp.json.return_value = {'type': 'record'}
+            return resp
+
+        codec._http_client = mock.Mock()
+        codec._http_client.get = fake_get
+        with mock.patch.object(codecs, 'httpx', _fake_httpx()):
+            task_a = asyncio.create_task(codec._avro_schema('type_a'))
+            task_b = asyncio.create_task(codec._avro_schema('type_b'))
+            for _ in range(10):
+                await asyncio.sleep(0)
+            self.assertEqual(max_in_flight, 2)
+            release.set()
+            await asyncio.gather(task_a, task_b)
+
+    async def test_same_type_fetched_once(self):
+        codec = _http_codec()
+        release = asyncio.Event()
+        calls = 0
+
+        async def fake_get(uri):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            resp = mock.Mock(status_code=200)
+            resp.json.return_value = {'type': 'record'}
+            return resp
+
+        codec._http_client = mock.Mock()
+        codec._http_client.get = fake_get
+        with mock.patch.object(codecs, 'httpx', _fake_httpx()):
+            task1 = asyncio.create_task(codec._avro_schema('same_type'))
+            task2 = asyncio.create_task(codec._avro_schema('same_type'))
+            for _ in range(10):
+                await asyncio.sleep(0)
+            release.set()
+            results = await asyncio.gather(task1, task2)
+        self.assertEqual(calls, 1)
+        self.assertEqual(results[0], results[1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -105,6 +105,17 @@ class AvroHttpSchemaTests(unittest.IsolatedAsyncioTestCase):
                 await codec._avro_schema('flaky_type')
         self.assertEqual(codec._http_client.get.await_count, 3)
 
+    async def test_failed_load_does_not_leak_lock(self):
+        codec = _http_codec()
+        response = mock.Mock(status_code=404)
+        codec._http_client = mock.Mock()
+        codec._http_client.get = mock.AsyncMock(return_value=response)
+        with mock.patch.object(codecs, 'httpx', _fake_httpx()):
+            with self.assertRaises(codecs.DecodeError):
+                await codec._avro_schema('missing_type')
+        self.assertNotIn('missing_type', codec._schema_locks)
+        self.assertNotIn('missing_type', codec._avro_schemas)
+
     async def test_different_types_load_concurrently(self):
         codec = _http_codec()
         release = asyncio.Event()


### PR DESCRIPTION
## Summary

Fixes 3 verified bugs in `codecs.py` that caused silent data corruption and lock contention.

## Problem / Solution

- **#83** `Codec.decode` silently returned raw bytes when the optional `umsgpack`/`bs4` dependency was missing → now raises `DecodeError` when the content type matches but the library is absent, matching the Avro pattern.
- **#96** `_compress` silently no-op'd for unrecognized `content_encoding`, emitting an uncompressed body whose AMQP property claimed a compression scheme → now raises `EncodeError`. (Decode-side pass-through is intentionally retained: a non-compression `content_encoding` like `utf-8` is legitimate on decode.)
- **#97** Avro HTTP schema loading serialized every load behind one global lock and retried deterministic 4xx with backoff → per-message-type `asyncio.Lock`, fail-fast on 4xx (5xx/network errors still retry).

A stateless `_decode_body` helper was extracted to keep `decode` under the mccabe limit after adding the missing-dependency guards (no behavior change).

## Testing

Full suite green (218 tests) + ruff clean. New `tests/test_codecs.py` (10 tests).

Closes #83
Closes #96
Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema caching so concurrent schema fetches for different message types run independently.
  * Avro schema HTTP loading now fails fast on client errors while still retrying transient server errors.
  * Unsupported compression settings now raise a clear encode error instead of passing through.
  * Streamlined decoding for common formats with consistent fallback behavior.

* **Tests**
  * Added unit tests for missing optional dependencies, compression validation/round-trips, and Avro schema HTTP behavior (fail-fast, retries, concurrency, and no lock leakage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->