### PR TITLE
Fix properties dict mutation in testing.create_context

### DIFF
--- a/rejected/testing.py
+++ b/rejected/testing.py
@@ -132,7 +132,7 @@ class AsyncTestCase(unittest.IsolatedAsyncioTestCase):
         message (matching production behavior).
 
         """
-        properties = properties or {}
+        properties = dict(properties) if properties else {}
         properties.setdefault('content_type', content_type)
         properties.setdefault('correlation_id', self.correlation_id)
         properties.setdefault(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -81,3 +81,23 @@ class TestUnhandledException(testing.AsyncTestCase):
     async def test_stacktrace(self):
         with self.assertRaises(ValueError):
             await self.process_message({'foo': 'bar'})
+
+
+class TestPropertiesNotMutated(testing.AsyncTestCase):
+    def get_consumer(self):
+        class TestConsumer(consumer.Consumer):
+            async def process(self):
+                pass
+
+        return TestConsumer
+
+    async def test_reused_properties_dict_not_mutated(self):
+        props = {'app_id': 'custom'}
+        ctx = self.create_context(
+            content_type='application/json', properties=props
+        )
+        self.assertEqual({'app_id': 'custom'}, props)
+        self.assertEqual('application/json', ctx.message.content_type)
+        ctx2 = self.create_context(content_type='text/plain', properties=props)
+        self.assertEqual({'app_id': 'custom'}, props)
+        self.assertEqual('text/plain', ctx2.message.content_type)


### PR DESCRIPTION
## Summary

Fixes a bug where `testing.AsyncTestCase.create_context` mutated the caller-supplied `properties` dict.

## Problem / Solution

- **#98** `create_context` used `properties = properties or {}` (keeping the caller's object) then wrote defaults via `setdefault`, so a caller reusing a non-empty dict across `process_message` calls got stale `content_type`/`type`/`timestamp` → copy-on-entry (`dict(properties) if properties else {}`).

## Testing

Full suite green (209 tests) + ruff clean. New test in `tests/test_testing.py` reproduces the mutation (verified failing before, passing after).

Closes #98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context creation so provided property dictionaries are no longer modified in place.
  * Reusing the same properties input across multiple context creations now keeps the original values intact, while each context still gets the correct content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->