### PR TITLE
Pass the process event loop through to AsyncioConnection

### DIFF
--- a/rejected/connection.py
+++ b/rejected/connection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import ssl
@@ -35,6 +36,7 @@ class Connection(state.State):
         should_consume: bool,
         publisher_confirmations: bool,
         callbacks: models.Callbacks,
+        ioloop: asyncio.AbstractEventLoop | None = None,
     ):
         super().__init__()
         self.blocked: bool = False
@@ -43,6 +45,7 @@ class Connection(state.State):
         self.config: models.ConnectionConfig = config
         self.should_consume: bool = should_consume
         self.consumer_tag: str = f'{consumer_name}-{os.getpid()}'
+        self.ioloop: asyncio.AbstractEventLoop | None = ioloop
         self.name: str = name
         self.publisher_confirm: bool = publisher_confirmations
         self.connection: asyncio_connection.AsyncioConnection = self.connect()
@@ -53,6 +56,11 @@ class Connection(state.State):
         opened, when there is an error opening a connection or when a
         previously opened connection is closed.
 
+        ``ioloop`` must be passed when connecting from outside a running
+        event loop (Process creates connections before starting its loop);
+        otherwise pika binds the connection workflow to a new event loop
+        that never runs and the connection silently never completes.
+
         """
         self.set_state(self.STATE_CONNECTING)
         return asyncio_connection.AsyncioConnection(
@@ -60,6 +68,7 @@ class Connection(state.State):
             on_open_callback=self.on_open,
             on_open_error_callback=self.on_open_error,
             on_close_callback=self.on_closed,
+            custom_ioloop=self.ioloop,
         )
 
     @property

--- a/rejected/process.py
+++ b/rejected/process.py
@@ -208,6 +208,7 @@ class Process(multiprocessing.Process, state.State):
                 consume,
                 confirm,
                 self.callbacks,
+                self.ioloop,
             )
 
     @staticmethod

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -59,6 +59,37 @@ def _make_connection(
         )
 
 
+class EventLoopBindingTests(unittest.TestCase):
+    def test_connect_passes_ioloop_to_pika(self) -> None:
+        """The connection workflow must run on the loop the caller owns:
+        pika creates its own never-run loop when connecting from outside
+        a running loop, so the ioloop must be passed through explicitly.
+
+        """
+        ioloop = mock.Mock()
+        cfg = _config().connections['MockConnection']
+        with mock.patch.object(
+            connection_mod.asyncio_connection, 'AsyncioConnection'
+        ) as asyncio_connection:
+            conn = connection_mod.Connection(
+                'MockConnection',
+                cfg,
+                'consumer',
+                True,
+                False,
+                _callbacks(),
+                ioloop,
+            )
+        self.assertIs(
+            asyncio_connection.call_args.kwargs['custom_ioloop'], ioloop
+        )
+        self.assertIs(conn.ioloop, ioloop)
+
+    def test_ioloop_defaults_to_none(self) -> None:
+        conn = _make_connection()
+        self.assertIsNone(conn.ioloop)
+
+
 class ShutdownTests(unittest.TestCase):
     def test_shutdown_is_noop_when_closed(self) -> None:
         """#74 shutting down an already-closed connection is a no-op."""


### PR DESCRIPTION
## Problem
`Process` creates its `Connection`s before starting the event loop with `run_forever()`. Since `Connection.connect()` doesn't pass `custom_ioloop`, pika's `_AsyncioIOServicesAdapter` calls `asyncio.get_running_loop()`, finds no running loop, and falls back to creating a **new** event loop that is never run. The AMQP connection workflow gets scheduled on that dead loop and never executes.

Symptom: consumers hang in `Connecting` forever with zero errors logged — pika logs `Starting AMQP Connection workflow asynchronously.` and then nothing; the MCP keeps reporting `processed 0 messages`, and no consumers ever appear on the queue.

## Solution
- `Connection` accepts an optional `ioloop` and forwards it to `AsyncioConnection` as `custom_ioloop`.
- `Process.create_connections()` passes `self.ioloop` (created in `_run()` before `setup()` runs).
- Reconnects are covered too, since they reuse the same `connect()` and the stored loop.
- Default stays `None` so the signature is backward compatible; connections created from inside a running loop behave as before.

## Testing
- New `EventLoopBindingTests` in `tests/test_connection.py` assert the loop reaches `AsyncioConnection` and the default remains `None`.
- Full suite: only the pre-existing `test_statsd.TCPTestCase` failures remain (also fail on unmodified `main`); no new failures. `pre-commit run -a` clean.
- Verified end-to-end against a real RabbitMQ over TLS: before the patch the consumer hangs in `Connecting` indefinitely; with it, the connection opens and `Basic.ConsumeOk` is received on the configured queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability when starting from outside an active event loop.
  * Connections can now use a caller-provided event loop when establishing messaging connections.
  * Existing behavior remains unchanged when no event loop is specified.

* **Tests**
  * Added coverage for custom event loop handling and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->